### PR TITLE
Changes to track elapsed time and mode along path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,7 @@ endif
 # lib valhalla compilation etc
 lib_LTLIBRARIES = libvalhalla_sif.la
 nobase_include_HEADERS = \
+	valhalla/sif/costconstants.h \
 	valhalla/sif/costfactory.h \
 	valhalla/sif/autocost.h \
 	valhalla/sif/bicyclecost.h \

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -144,8 +144,7 @@ class AutoCost : public DynamicCost {
 
 // Constructor
 AutoCost::AutoCost(const boost::property_tree::ptree& pt)
-    : DynamicCost(pt) {
-
+    : DynamicCost(pt, TravelMode::kDrive) {
   maneuver_penalty_ = pt.get<float>("maneuver_penalty",
                                     kDefaultManeuverPenalty);
   gate_cost_ = pt.get<float>("gate_cost", kDefaultGateCost);

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -152,7 +152,7 @@ class BicycleCost : public DynamicCost {
 
 // Constructor
 BicycleCost::BicycleCost(const boost::property_tree::ptree& config)
-    : DynamicCost(config),
+    : DynamicCost(config, TravelMode::kBicycle),
       speed_(25.0f),
       bicycletype_(BicycleType::kRoad),
       smooth_surface_factor_(0.9f),

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -5,8 +5,10 @@ using namespace valhalla::baldr;
 namespace valhalla{
 namespace sif {
 
-DynamicCost::DynamicCost(const boost::property_tree::ptree& pt)
-    : not_thru_distance_(5000.0f) {
+DynamicCost::DynamicCost(const boost::property_tree::ptree& pt,
+                         const TravelMode mode)
+    : travelmode_(mode),
+      not_thru_distance_(5000.0f) {
   // Parse property tree to get hierarchy limits
   // TODO - get the number of levels
   for (uint32_t level = 0; level <= 8; level++) {
@@ -62,6 +64,16 @@ void DynamicCost::RelaxHierarchyLimits(const float factor) {
 // resort.
 void DynamicCost::DisableHighwayTransitions() {
   hierarchy_limits_[1].DisableHighwayTransitions();
+}
+
+// Set the current travel mode.
+void DynamicCost::set_travelmode(const TravelMode mode) {
+  travelmode_ = mode;
+}
+
+// Get the current travel mode.
+TravelMode DynamicCost::travelmode() const {
+  return travelmode_;
 }
 
 // Set the distance from the destination where "not_thru" edges are allowed.

--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -9,7 +9,7 @@ namespace sif {
 EdgeLabel::EdgeLabel()
     : predecessor_(kInvalidLabel),
       edgeid_(GraphId()),
-      cost_(0.0f),
+      cost_{0.0f, 0.0f},
       sortcost_(0.0f),
       distance_(0.0f),
       attributes_{} {
@@ -17,10 +17,11 @@ EdgeLabel::EdgeLabel()
 
 // Constructor with values.
 EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
-                     const DirectedEdge* edge, const float cost,
+                     const DirectedEdge* edge, const Cost& cost,
                      const float sortcost, const float dist,
                      const uint32_t restrictions,
-                     const uint32_t opp_local_idx)
+                     const uint32_t opp_local_idx,
+                     const TravelMode mode)
     : predecessor_(predecessor),
       edgeid_(edgeid),
       endnode_(edge->endnode()),
@@ -32,6 +33,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
   attributes_.trans_up      = edge->trans_up();
   attributes_.trans_down    = edge->trans_down();
   attributes_.shortcut      = edge->shortcut();
+  attributes_.mode          = static_cast<uint32_t>(mode);
 }
 
 // Destructor
@@ -39,11 +41,12 @@ EdgeLabel::~EdgeLabel() {
 }
 
 // Update predecessor and cost values in the label.
-void EdgeLabel::Update(const uint32_t predecessor, const float cost,
-                       const float sortcost) {
+void EdgeLabel::Update(const uint32_t predecessor, const Cost& cost,
+                       const float sortcost, const TravelMode mode) {
   predecessor_ = predecessor;
   cost_ = cost;
   sortcost_ = sortcost;
+  attributes_.mode = static_cast<uint32_t>(mode);
 }
 
 // Get the predecessor edge label index.
@@ -61,6 +64,11 @@ const baldr::GraphId& EdgeLabel::endnode() const {
   return endnode_;
 }
 
+// Get the cost from the origin to this directed edge.
+const Cost& EdgeLabel::cost() const {
+  return cost_;
+}
+
 // Get the sort cost.
 float EdgeLabel::sortcost() const {
   return sortcost_;
@@ -69,11 +77,6 @@ float EdgeLabel::sortcost() const {
 // Set the sort cost
 void EdgeLabel::SetSortCost(float sortcost) {
 sortcost_ = sortcost;
-}
-
-// Get the cost from the origin to this directed edge.
-float EdgeLabel::cost() const {
-  return cost_;
 }
 
 // Get the distance to the destination.
@@ -107,6 +110,11 @@ bool EdgeLabel::trans_down() const {
 // Get the shortcut flag.
 bool EdgeLabel::shortcut() const {
   return attributes_.shortcut;
+}
+
+// Get the travel mode along this edge.
+TravelMode EdgeLabel::mode() const {
+  return static_cast<TravelMode>(attributes_.mode);
 }
 
 // Operator for sorting.

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -126,7 +126,7 @@ class PedestrianCost : public DynamicCost {
 // Constructor. Parse pedestrian options from property tree. If option is
 // not present, set the default.
 PedestrianCost::PedestrianCost(const boost::property_tree::ptree& pt)
-    : DynamicCost(pt) {
+    : DynamicCost(pt, TravelMode::kPedestrian) {
   walking_speed_   = pt.get<float>("walking_speed", kDefaultWalkingSpeed);
   walkway_factor_  = pt.get<float>("walkway_factor", kDefaultWalkwayFactor);
   alley_factor_    = pt.get<float>("alley_factor_", kDefaultAlleyFactor);

--- a/valhalla/sif/costconstants.h
+++ b/valhalla/sif/costconstants.h
@@ -1,0 +1,96 @@
+#ifndef VALHALLA_SIF_COST_CONSTANTS_H_
+#define VALHALLA_SIF_COST_CONSTANTS_H_
+
+namespace valhalla {
+namespace sif {
+
+// Travel modes
+enum class TravelMode : uint8_t {
+   kDrive = 0,
+   kPedestrian = 1,
+   kBicycle = 2,
+   kPublicTransit = 3
+};
+
+// TODO - add specific types (car, foot, road bike, etc.)
+
+
+/**
+ * Simple structure for returning costs. Includes cost and true elapsed time
+ * in seconds.
+ */
+struct Cost {
+  float cost;
+  float secs;
+
+  /**
+   * Default constructor
+   */
+  Cost()
+      : cost(0.0f),
+        secs(0.0f) {
+  }
+
+  /**
+   * Constructor given cost and seconds.
+   * @param  c  Cost (units defined by the costing model)
+   * @param  s  Time in seconds.
+   */
+  Cost(const float c, const float s)
+       : cost(c),
+         secs(s) {
+  }
+
+  /**
+   * Add 2 costs.
+   * @param  other  Cost to add to this cost.
+   * @return  Returns the sum of the costs.
+   */
+  Cost operator + (const Cost& other) const {
+    return Cost(cost + other.cost, secs + other.secs);
+  }
+
+  /**
+   * Scale this cost by a factor (for partial costs along edges).
+   * @param  f  Scale / multiplication factor.
+   * @return  Returns address of this cost.
+   */
+  Cost& operator *= (const float f) {
+    cost *= f;
+    secs *= f;
+    return *this;
+  }
+
+  /**
+   * Scale the cost by a factor (for partial costs along edges).
+   * @param   f  Scale / multiplication factor.
+   * @return  Returns a new cost that is the product of this cost and
+   *          the scaling factor.
+   */
+  Cost operator * (const float f) const {
+    return Cost(cost * f, secs * f);
+  }
+
+  /**
+   * Less than operator - compares cost.
+   * @param  other  Cost to compare against.
+   * @return  Returns true if this cost is less than the other cost.
+   */
+  bool operator < (const Cost& other) const {
+    return cost < other.cost;
+  }
+
+  /**
+   * Greater than operator - compares cost.
+   * @param  other  Cost to compare against.
+   * @return  Returns true if this cost is greater than the other cost.
+   */
+  bool operator > (const Cost& other) const {
+    return cost > other.cost;
+  }
+};
+
+}
+}
+
+#endif  // VALHALLA_SIF_COST_CONSTANTS_H_

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -7,6 +7,7 @@
 
 #include <valhalla/sif/hierarchylimits.h>
 #include <valhalla/sif/edgelabel.h>
+#include <valhalla/sif/costconstants.h>
 
 namespace valhalla {
 namespace sif {
@@ -19,29 +20,6 @@ using EdgeFilter = std::function<bool (const baldr::DirectedEdge*)>;
 
 // Default unit size (seconds) for cost sorting.
 constexpr uint32_t kDefaultUnitSize = 1;
-
-// Simple structure for returning costs
-struct Cost {
-  float cost;
-  float seconds;
-
-  // Default constructor
-  Cost()
-      : cost(0.0f),
-        seconds(0.0f) {
-  }
-
-  // Constructor with args
-  Cost(const float c, const float s)
-       : cost(c),
-         seconds(s) {
-  }
-
-  // Add 2 costs
-  Cost operator + (const Cost& other) const {
-    return Cost(cost + other.cost, seconds + other.seconds);
-  }
-};
 
 /**
  * Base class for dynamic edge costing. This class defines the interface for
@@ -60,9 +38,11 @@ class DynamicCost {
  public:
   /**
    * Constructor.
-   * @param  pt  Property tree with (optional) costing configuration.
+   * @param  pt   Property tree with (optional) costing configuration.
+   * @param  mode Travel mode
    */
-  DynamicCost(const boost::property_tree::ptree& pt);
+  DynamicCost(const boost::property_tree::ptree& pt,
+              const TravelMode mode);
 
   virtual ~DynamicCost();
 
@@ -148,6 +128,18 @@ class DynamicCost {
   virtual uint32_t UnitSize() const;
 
   /**
+   * Set the current travel mode.
+   * @param  mode  Travel mode
+   */
+  void set_travelmode(const TravelMode mode);
+
+  /**
+   * Get the current travel mode.
+   * @return  Returns the current travel mode.
+   */
+  TravelMode travelmode() const;
+
+  /**
    * Set the distance from the destination where "not_thru" edges are allowed.
    * @param  d  Distance in meters.
    */
@@ -182,6 +174,9 @@ class DynamicCost {
   void ResetHierarchyLimits();
 
  protected:
+  // Travel mode
+  TravelMode travelmode_;
+
   // Hierarchy limits.
   std::vector<HierarchyLimits> hierarchy_limits_;
 


### PR DESCRIPTION
Separate Cost and TravelModes into new costconstants.h include. Add Cost to EdgeLabel (replace cost in seconds) - this allows EdgeLabel to track elapsed time along the path. Add TravelMode to EdgeLabel and cost methods