### PR TITLE
Remove to_idx from TransitionCost

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -88,13 +88,11 @@ class AutoCost : public DynamicCost {
    * @param  edge  Directed edge (the to edge)
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  Predecessor edge information.
-   * @param   to_idx Index of the "to" directed edge.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred,
-                              const uint32_t to_idx) const;
+                              const EdgeLabel& pred) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -211,8 +209,7 @@ Cost AutoCost::EdgeCost(const DirectedEdge* edge,
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
                                const baldr::NodeInfo* node,
-                               const EdgeLabel& pred,
-                               const uint32_t to_idx) const {
+                               const EdgeLabel& pred) const {
   // Special cases: gate, toll booth, false intersections
   // TODO - do we want toll booth penalties?
 
@@ -231,7 +228,7 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
     float seconds = edge->stopimpact(idx) * TurnCost(edge->turntype(idx),
                          edge->edge_to_right(idx) && edge->edge_to_left(idx),
                          edge->drive_on_right());
-    return (node->name_consistency(idx, to_idx)) ?
+    return (node->name_consistency(idx, edge->localedgeidx())) ?
               Cost(seconds, seconds) :
               Cost(seconds + maneuver_penalty_, seconds);
   }

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -37,8 +37,7 @@ bool DynamicCost::AllowMultiPass() const {
 // costs (i.e., intersection/turn costs) must override this method.
 Cost DynamicCost::TransitionCost(const DirectedEdge* edge,
                                  const NodeInfo* node,
-                                 const EdgeLabel& pred,
-                                 const uint32_t to_idx) const {
+                                 const EdgeLabel& pred) const {
   return Cost(0.0f, 0.0f);
 }
 

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -68,13 +68,11 @@ class PedestrianCost : public DynamicCost {
    * @param  edge  Directed edge (the to edge)
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  Predecessor edge information.
-   * @param  to_idx Index of the "to" directed edge.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred,
-                              const uint32_t to_idx) const;
+                              const EdgeLabel& pred) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -177,8 +175,7 @@ Cost PedestrianCost::EdgeCost(const baldr::DirectedEdge* edge,
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost PedestrianCost::TransitionCost(const baldr::DirectedEdge* edge,
                                const baldr::NodeInfo* node,
-                               const EdgeLabel& pred,
-                               const uint32_t to_idx) const {
+                               const EdgeLabel& pred) const {
   // Special cases: fixed penalty for steps/stairs
   if (edge->use() == Use::kSteps) {
     return { step_penalty_, 0.0f };

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -96,13 +96,11 @@ class DynamicCost {
    * @param   edge  Directed edge (the to edge)
    * @param   node  Node (intersection) where transition occurs.
    * @param   pred  Predecessor edge information.
-   * @param   to_idx Index of the "to" directed edge.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred,
-                              const uint32_t to_idx) const;
+                              const EdgeLabel& pred) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied


### PR DESCRIPTION
we really needed the localedgeidx which is part of DirectedEdge.