### PR TITLE
Add transit information (tripId, prior stop Id, walking distance).

### DIFF
--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -12,7 +12,11 @@ EdgeLabel::EdgeLabel()
       cost_{0.0f, 0.0f},
       sortcost_(0.0f),
       distance_(0.0f),
-      attributes_{} {
+      attributes_{},
+      tripid_(0),
+      prior_stopid_(0),
+      blockid_(0),
+      walking_distance_(0.0f) {
 }
 
 // Constructor with values.
@@ -27,7 +31,37 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       endnode_(edge->endnode()),
       cost_(cost),
       sortcost_(sortcost),
-      distance_(dist) {
+      distance_(dist),
+      tripid_(0),
+      prior_stopid_(0),
+      blockid_(0),
+      walking_distance_(0.0f) {
+  attributes_.opp_local_idx = opp_local_idx;
+  attributes_.restrictions  = restrictions;
+  attributes_.trans_up      = edge->trans_up();
+  attributes_.trans_down    = edge->trans_down();
+  attributes_.shortcut      = edge->shortcut();
+  attributes_.mode          = static_cast<uint32_t>(mode);
+}
+
+// Constructor with values.  Used for multi-modal path.
+EdgeLabel::EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
+          const baldr::DirectedEdge* edge, const Cost& cost,
+          const float sortcost, const float dist,
+          const uint32_t restrictions, const uint32_t opp_local_idx,
+          const TravelMode mode, const uint32_t tripid,
+          const uint32_t prior_stopid, const uint32_t blockid,
+          const float walking_distance)
+    : predecessor_(predecessor),
+      edgeid_(edgeid),
+      endnode_(edge->endnode()),
+      cost_(cost),
+      sortcost_(sortcost),
+      distance_(dist),
+      tripid_(tripid),
+      prior_stopid_(prior_stopid),
+      blockid_(blockid),
+      walking_distance_(walking_distance) {
   attributes_.opp_local_idx = opp_local_idx;
   attributes_.restrictions  = restrictions;
   attributes_.trans_up      = edge->trans_up();
@@ -115,6 +149,26 @@ bool EdgeLabel::shortcut() const {
 // Get the travel mode along this edge.
 TravelMode EdgeLabel::mode() const {
   return static_cast<TravelMode>(attributes_.mode);
+}
+
+// Get the transit trip Id.
+uint32_t EdgeLabel::tripid() const {
+  return tripid_;
+}
+
+// Get the prior transit stop Id.
+uint32_t EdgeLabel::prior_stopid() const {
+  return prior_stopid_;
+}
+
+// Return the transit block Id of the prior trip.
+uint32_t EdgeLabel::blockid() const {
+  return blockid_;
+}
+
+// Get the current walking distance.
+float EdgeLabel::walking_distance() const {
+  return walking_distance_;
 }
 
 // Operator for sorting.

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -46,6 +46,33 @@ class EdgeLabel {
             const TravelMode mode);
 
   /**
+   * Constructor with values.  Used for multi-modal path.
+   * @param predecessor Index into the edge label list for the predecessor
+   *                       directed edge in the shortest path.
+   * @param edgeid    Directed edge.
+   * @param endnode   End node of the directed edge.
+   * @param cost      True cost (cost and elapsed time in seconds) to the edge.
+   * @param sortcost  Cost for sorting (includes A* heuristic)
+   * @param dist      Distance meters to the destination
+   * @param restrictions Restriction mask from prior edge - this is used
+   *                  if edge is a transition edge. This allows restrictions
+   *                  to be carried across different hierarchy levels.
+   * @param mode      Mode of travel along this edge.
+   * @param tripid    Trip Id for a transit edge.
+   * @param prior_stopid  Prior transit stop Id.
+   * @param blockid   Transit trip block Id.
+   * @param walking_distance  Accumulated walking distance (reset when mode
+   *                          changes.
+   */
+  EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
+            const baldr::DirectedEdge* edge, const Cost& cost,
+            const float sortcost, const float dist,
+            const uint32_t restrictions, const uint32_t opp_local_idx,
+            const TravelMode mode, const uint32_t tripid,
+            const uint32_t prior_stopid, const uint32_t blockid,
+            const float walking_distance);
+
+  /**
    * Destructor.
    */
   virtual ~EdgeLabel();
@@ -149,14 +176,35 @@ class EdgeLabel {
   TravelMode mode() const;
 
   /**
+   * Get the transit trip Id.
+   * @return   Returns the transit trip Id of the prior edge.
+   */
+  uint32_t tripid() const;
+
+  /**
+   * Get the prior transit stop Id.
+   * @return  Returns the prior transit stop Id.
+   */
+  uint32_t prior_stopid() const;
+
+  /**
+   * Return the transit block Id of the prior trip.
+   * @return  Returns the block Id.
+   */
+  uint32_t blockid() const;
+
+  /**
+   * Get the current walking distance.
+   * @return  Returns the current walking distance accumulated since last stop.
+   */
+  float walking_distance() const;
+
+  /**
    * Operator < used for sorting.
    */
   bool operator < (const EdgeLabel& other) const;
 
  private:
-  // Index to the predecessor edge label information.
-  uint32_t predecessor_;
-
   // Graph Id of the edge.
   baldr::GraphId edgeid_;
 
@@ -167,6 +215,9 @@ class EdgeLabel {
 
   // Cost and elapsed time along the path
   Cost cost_;
+
+  // Index to the predecessor edge label information.
+  uint32_t predecessor_;
 
   // Sort cost - includes A* heuristic
   float sortcost_;
@@ -184,7 +235,6 @@ class EdgeLabel {
    * shortcut:      Was the prior edge a shortcut edge?
    * restrictions:  Bit mask of edges (by local edge index at the end node)
    *                that are restricted (simple turn restrictions)
-
    */
   struct Attributes {
     uint32_t opp_local_idx : 7;
@@ -199,6 +249,18 @@ class EdgeLabel {
 
   // Transit information...trip ID , prior stop ID, time at stop? This
   // could be be part of a derived class used only in multimodal routes?
+
+  // Transit trip Id
+  uint32_t tripid_;
+
+  // Prior stop Id
+  uint32_t prior_stopid_;
+
+  // Block Id
+  uint32_t blockid_;
+
+  // Current walking distance. Resets to 0 when changing to a non-walking mode.
+  float walking_distance_;
 };
 
 }


### PR DESCRIPTION
Rearrange fields to minimize size (increased from 56 bytes to 64 even though 4 new 4 byte fields were added).