### PR TITLE
Flag to disable use of transit connections

### DIFF
--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -7,7 +7,8 @@ namespace sif {
 
 DynamicCost::DynamicCost(const boost::property_tree::ptree& pt,
                          const TravelMode mode)
-    : travelmode_(mode),
+    : allow_transit_connections_(false),
+      travelmode_(mode),
       not_thru_distance_(5000.0f) {
   // Parse property tree to get hierarchy limits
   // TODO - get the number of levels
@@ -56,6 +57,12 @@ Cost DynamicCost::TransitionCost(const DirectedEdge* edge,
 uint32_t DynamicCost::UnitSize() const {
   return kDefaultUnitSize;
 }
+
+// Set to allow use of transit connections.
+void DynamicCost::SetAllowTransitConnections(const bool allow) {
+  allow_transit_connections_ = allow;
+}
+
 
 // Gets the hierarchy limits.
 std::vector<HierarchyLimits>& DynamicCost::GetHierarchyLimits() {

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -140,6 +140,12 @@ class DynamicCost {
   virtual uint32_t UnitSize() const;
 
   /**
+   * Set to allow use of transit connections.
+   * @param  allow  Flag indicating whether transit connections are allowed.
+   */
+  virtual void SetAllowTransitConnections(const bool allow);
+
+  /**
    * Set the current travel mode.
    * @param  mode  Travel mode
    */
@@ -186,6 +192,9 @@ class DynamicCost {
   void ResetHierarchyLimits();
 
  protected:
+  // Flag indicating whether transit connections are allowed.
+  bool allow_transit_connections_;
+
   // Travel mode
   TravelMode travelmode_;
 


### PR DESCRIPTION
In pedestrian costing allow transit connections when doing multimodal routes and disable when pedestrian only (don't want to cur through transit stations!).