### PR TITLE
added bus costing.

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -409,8 +409,6 @@ class BusCost : public AutoCost {
    */
   virtual const EdgeFilter GetFilter() const;
 
- protected:
-  float adjspeedfactor_[256];
 };
 
 

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -186,12 +186,12 @@ bool AutoCost::AllowMultiPass() const {
   return true;
 }
 
-// Check if access is allowed on the specified edge. Not worh checking
+// Check if access is allowed on the specified edge. Not worth checking
 // not_thru due to hierarchy transitions
 bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred) const {
-  // Check access, Uturn, and simple turn restriction.
-  // TODO - perhaps allow Uturns at dead-end nodes?
+  // Check access, U-turn, and simple turn restriction.
+  // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(edge->forwardaccess() & kAutoAccess) ||
       (pred.opp_local_idx() == edge->localedgeidx()) ||
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
@@ -299,7 +299,8 @@ cost_ptr_t CreateAutoCost(const boost::property_tree::ptree& config) {
 }
 
 /**
- * Derived class providing dynamic edge costing for pedestrian routes.
+ * Derived class providing an alternate costing for driving that is intended
+ * to provide a short path.
  */
 class AutoShorterCost : public AutoCost {
  public:
@@ -366,6 +367,95 @@ float AutoShorterCost::AStarCostFactor() const {
 cost_ptr_t CreateAutoShorterCost(const boost::property_tree::ptree& config) {
   return std::make_shared<AutoShorterCost>(config);
 }
+
+/**
+ * Derived class providing bus costing for driving.
+ */
+class BusCost : public AutoCost {
+ public:
+  /**
+   * Construct auto costing for shorter (not absolute shortest) path.
+   * Pass in configuration using property tree.
+   * @param  config  Property tree with configuration/options.
+   */
+  BusCost(const boost::property_tree::ptree& config);
+
+  virtual ~BusCost();
+
+  /**
+   * Checks if access is allowed for the provided directed edge.
+   * This is generally based on mode of travel and the access modes
+   * allowed on the edge. However, it can be extended to exclude access
+   * based on other parameters.
+   * @param  edge  Pointer to a directed edge.
+   * @param  pred  Predecessor edge information.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool Allowed(const baldr::DirectedEdge* edge,
+                       const EdgeLabel& pred) const;
+
+  /**
+   * Checks if access is allowed for the provided node. Node access can
+   * be restricted if bollards or gates are present.
+   * @param  edge  Pointer to node information.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool Allowed(const baldr::NodeInfo* node) const;
+
+  /**
+   * Returns a function/functor to be used in location searching which will
+   * exclude results from the search by looking at each edges attribution
+   * @return Function/functor to be used in filtering out edges
+   */
+  virtual const EdgeFilter GetFilter() const;
+
+ protected:
+  float adjspeedfactor_[256];
+};
+
+
+// Constructor
+BusCost::BusCost(const boost::property_tree::ptree& pt)
+    : AutoCost(pt) {
+}
+
+// Destructor
+BusCost::~BusCost() {
+}
+
+// Check if access is allowed on the specified edge. Not worth checking
+// not_thru due to hierarchy transitions
+bool BusCost::Allowed(const baldr::DirectedEdge* edge,
+                       const EdgeLabel& pred) const {
+  // Check access, U-turn, and simple turn restriction.
+  // TODO - perhaps allow U-turns at dead-end nodes?
+  if (!(edge->forwardaccess() & kBusAccess) ||
+      (pred.opp_local_idx() == edge->localedgeidx()) ||
+      (pred.restrictions() & (1 << edge->localedgeidx())) ||
+       edge->surface() == Surface::kImpassable) {
+    return false;
+  }
+
+  return true;
+}
+
+// Check if access is allowed at the specified node.
+bool BusCost::Allowed(const baldr::NodeInfo* node) const  {
+  return (node->access() & kBusAccess);
+}
+
+// Function/functor to be used in filtering out edges
+const EdgeFilter BusCost::GetFilter() const {
+  //throw back a lambda that checks the access for this type of costing
+  return [](const baldr::DirectedEdge* edge){
+    return edge->trans_up() || edge->trans_down() || !(edge->forwardaccess() & kBusAccess);
+  };
+}
+
+cost_ptr_t CreateBusCost(const boost::property_tree::ptree& config) {
+  return std::make_shared<BusCost>(config);
+}
+
 
 }
 }

--- a/valhalla/sif/autocost.h
+++ b/valhalla/sif/autocost.h
@@ -22,6 +22,13 @@ cost_ptr_t CreateAutoCost(const boost::property_tree::ptree& config);
  */
 cost_ptr_t CreateAutoShorterCost(const boost::property_tree::ptree& config);
 
+/**
+ * Create a bus cost method. This is derived from auto costing and
+ * uses the same rules except for using the bus access flag instead
+ * of the auto access flag.
+ */
+cost_ptr_t CreateBusCost(const boost::property_tree::ptree& config);
+
 }
 }
 


### PR DESCRIPTION
Great example in Pittsburgh:

Autos can not drive on East Busway.

![bus](https://cloud.githubusercontent.com/assets/2676277/7862965/684a7d26-0527-11e5-81b6-0363f1bc3f33.png)

Auto Costing:
http://localhost:8002/route?json={%22locations%22:[{%22lat%22:40.4141036,%22lon%22:-79.8766083},{%22lat%22:40.4145961,%22lon%22:-79.8777316}],%22costing%22:%20%22auto%22,%22directions_options%22:{%22units%22:%22miles%22}}&api_key=valhalla-T_YY31g

"maneuvers": [

{

    "begin_shape_index": 0,
    "length": 0.048,
    "end_shape_index": 3,
    "instruction": "Go north on South Braddock Avenue/Green Belt.",
    "street_names": 

    [
        "South Braddock Avenue",
        "Green Belt"
    ],
    "type": 1,
    "time": 0

},
{

    "begin_shape_index": 3,
    "length": 0.05,
    "end_shape_index": 4,
    "instruction": "Turn left onto Mc Kim Street.",
    "street_names": 

    [
        "Mc Kim Street"
    ],
    "type": 15,
    "time": 22

},

Bus Costing:
http://localhost:8002/route?json={%22locations%22:[{%22lat%22:40.4141036,%22lon%22:-79.8766083},{%22lat%22:40.4145961,%22lon%22:-79.8777316}],%22costing%22:%20%22bus%22,%22directions_options%22:{%22units%22:%22miles%22}}&api_key=valhalla-T_YY31g

"maneuvers": [

{

    "begin_shape_index": 0,
    "length": 0.035,
    "end_shape_index": 2,
    "instruction": "Go north on South Braddock Avenue/Green Belt.",
    "street_names": 

    [
        "South Braddock Avenue",
        "Green Belt"
    ],
    "type": 1,
    "time": 0

},
{

    "begin_shape_index": 2,
    "length": 0.055,
    "end_shape_index": 3,
    "instruction": "Turn left onto East Busway.",
    "street_names": 

    [
        "East Busway"
    ],
    "type": 15,
    "time": 214

},