### PR TITLE
Use arterial further from destination

### DIFF
--- a/valhalla/sif/hierarchylimits.h
+++ b/valhalla/sif/hierarchylimits.h
@@ -17,7 +17,7 @@ constexpr uint32_t kDefaultMaxUpTransitions[] = {
 // Default distances within which expansion is always allowed
 // (per level)
 constexpr float kDefaultExpansionWithinDist[] = {
-    kMaxDistance, 10000.0f, 5000.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+    kMaxDistance, 250000.0f, 5000.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
 
 // Default distances outside which upward transitions are allowed
 // (per level)


### PR DESCRIPTION
Increase distance from destination where expansion on arterial level is allowed.