### PR TITLE
Add method to use max mode distances

### DIFF
--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -68,6 +68,14 @@ void DynamicCost::SetAllowTransitConnections(const bool allow) {
   allow_transit_connections_ = allow;
 }
 
+// This method overrides the max_distance with the multi-modal per segment
+// distance. An example is a pure walking route may have a max distance of
+// 10000 meters (10km) but for a multi-modal route a lower limit of 5000
+// meters per segment (e.g. from origin to a transit stop or from the last
+// transit stop to the destination).
+void DynamicCost::UseMaxModeDistance() {
+  ;
+}
 
 // Gets the hierarchy limits.
 std::vector<HierarchyLimits>& DynamicCost::GetHierarchyLimits() {

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -62,6 +62,15 @@ class DynamicCost {
   virtual bool AllowMultiPass() const;
 
   /**
+   * This method overrides the max_distance with the multi-modal per segment
+   * distance. An example is a pure walking route may have a max distance of
+   * 10000 meters (10km) but for a multi-modal route a lower limit of 5000
+   * meters per segment (e.g. from origin to a transit stop or from the last
+   * transit stop to the destination).
+   */
+  virtual void UseMaxModeDistance();
+
+  /**
    * Checks if access is allowed for the provided directed edge.
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access


### PR DESCRIPTION
 (e.g. max walking distance for a segment of a multi-modal route). 
Add max mode distance for walking so we can limit the walking portions of transit routes.
TODO - should add mode specific maximum for bicycle when we get to that.