### PR TITLE
Add costing methods for reverse path

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -77,6 +77,20 @@ class AutoCost : public DynamicCost {
                        const EdgeLabel& pred) const;
 
   /**
+   * Checks if access is allowed for an edge on the reverse path
+   * (from destination towards origin). Both opposing edges are
+   * provided.
+   * @param  edge  Pointer to a directed edge.
+   * @param  opp_edge  Pointer to the opposing directed edge.
+   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
+   *                        predecessor.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
+                 const baldr::DirectedEdge* opp_edge,
+                 const baldr::DirectedEdge* opp_pred_edge) const;
+
+  /**
    * Checks if access is allowed for the provided node. Node access can
    * be restricted if bollards or gates are present.
    * @param  edge  Pointer to node information.
@@ -215,7 +229,22 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
        edge->surface() == Surface::kImpassable) {
     return false;
   }
+  return true;
+}
 
+// Checks if access is allowed for an edge on the reverse path (from
+// destination towards origin). Both opposing edges are provided.
+bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
+               const baldr::DirectedEdge* opp_edge,
+               const baldr::DirectedEdge* opp_pred_edge) const {
+  // Check access, U-turn, and simple turn restriction.
+  // TODO - perhaps allow U-turns at dead-end nodes?
+  if (!(opp_edge->forwardaccess() & kAutoAccess) ||
+       (opp_pred_edge->localedgeidx() == edge->localedgeidx()) ||
+       (opp_edge->restrictions() & (1 << opp_pred_edge->localedgeidx())) ||
+       opp_edge->surface() == Surface::kImpassable) {
+    return false;
+  }
   return true;
 }
 
@@ -411,6 +440,20 @@ class BusCost : public AutoCost {
                        const EdgeLabel& pred) const;
 
   /**
+   * Checks if access is allowed for an edge on the reverse path
+   * (from destination towards origin). Both opposing edges are
+   * provided.
+   * @param  edge  Pointer to a directed edge.
+   * @param  opp_edge  Pointer to the opposing directed edge.
+   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
+   *                        predecessor.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
+                 const baldr::DirectedEdge* opp_edge,
+                 const baldr::DirectedEdge* opp_pred_edge) const;
+
+  /**
    * Checks if access is allowed for the provided node. Node access can
    * be restricted if bollards or gates are present.
    * @param  edge  Pointer to node information.
@@ -449,7 +492,22 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
        edge->surface() == Surface::kImpassable) {
     return false;
   }
+  return true;
+}
 
+// Checks if access is allowed for an edge on the reverse path (from
+// destination towards origin). Both opposing edges are provided.
+bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
+               const baldr::DirectedEdge* opp_edge,
+               const baldr::DirectedEdge* opp_pred_edge) const {
+  // Check access, U-turn, and simple turn restriction.
+  // TODO - perhaps allow U-turns at dead-end nodes?
+  if (!(opp_edge->forwardaccess() & kBusAccess) ||
+      (opp_pred_edge->opp_local_idx() == opp_edge->opp_local_idx()) ||
+      (opp_edge->restrictions() & (1 << opp_pred_edge->localedgeidx())) ||
+       opp_edge->surface() == Surface::kImpassable) {
+    return false;
+  }
   return true;
 }
 

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -52,6 +52,16 @@ Cost DynamicCost::TransitionCost(const DirectedEdge* edge,
   return { 0.0f, 0.0f };
 }
 
+// Returns the cost to make the transition from the predecessor edge
+// when using a reverse search (from destination towards the origin).
+// Defaults to 0. Costing models that wish to include edge transition
+// costs (i.e., intersection/turn costs) must override this method.
+Cost DynamicCost::TransitionCostReverse(const uint32_t idx,
+                            const baldr::NodeInfo* node,
+                            const baldr::DirectedEdge* opp_pred_edge) const {
+  return { 0.0f, 0.0f };
+}
+
 // Returns the transfer cost between 2 transit stops.
 Cost DynamicCost::TransferCost(const TransitTransfer* transfer) const {
   return { 0.0f, 0.0f };

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -53,6 +53,20 @@ class TransitCost : public DynamicCost {
                        const EdgeLabel& pred) const;
 
   /**
+   * Checks if access is allowed for an edge on the reverse path
+   * (from destination towards origin). Both opposing edges are
+   * provided.
+   * @param  edge  Pointer to a directed edge.
+   * @param  opp_edge  Pointer to the opposing directed edge.
+   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
+   *                        predecessor.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
+                 const baldr::DirectedEdge* opp_edge,
+                 const baldr::DirectedEdge* opp_pred_edge) const;
+
+  /**
    * Checks if access is allowed for the provided node. Node access can
    * be restricted if bollards or gates are present.
    * @param  edge  Pointer to node information.
@@ -169,6 +183,16 @@ bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
     return allow_rail_;
   }
   return true;
+}
+
+// Checks if access is allowed for an edge on the reverse path (from
+// destination towards origin). Both opposing edges are provided.
+bool TransitCost::AllowedReverse(const baldr::DirectedEdge* edge,
+               const baldr::DirectedEdge* opp_edge,
+               const baldr::DirectedEdge* opp_pred_edge) const {
+  // This method should not be called since time based routes do not use
+  // bidirectional A*
+  return false;
 }
 
 // Check if access is allowed at the specified node.

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -83,6 +83,20 @@ class DynamicCost {
                        const EdgeLabel& pred) const = 0;
 
   /**
+   * Checks if access is allowed for an edge on the reverse path
+   * (from destination towards origin). Both opposing edges are
+   * provided.
+   * @param  edge  Pointer to a directed edge.
+   * @param  opp_edge  Pointer to the opposing directed edge.
+   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
+   *                        predecessor.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
+                 const baldr::DirectedEdge* opp_edge,
+                 const baldr::DirectedEdge* opp_pred_edge) const = 0;
+
+  /**
    * Checks if access is allowed for the provided node. Node access can
    * be restricted if bollards are present.
    * @param   node  Pointer to node information.
@@ -125,6 +139,21 @@ class DynamicCost {
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
                               const EdgeLabel& pred) const;
+
+  /**
+   * Returns the cost to make the transition from the predecessor edge
+   * when using a reverse search (from destination towards the origin).
+   * Defaults to 0. Costing models that wish to include edge transition
+   * costs (i.e., intersection/turn costs) must override this method.
+   * @param  idx   Directed edge local index
+   * @param  node  Node (intersection) where transition occurs.
+   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
+   *                        predecessor.
+   * @return  Returns the cost and time (seconds)
+   */
+  virtual Cost TransitionCostReverse(const uint32_t idx,
+                              const baldr::NodeInfo* node,
+                              const baldr::DirectedEdge* opp_pred_edge) const;
 
   /**
    * Returns the transfer cost between 2 transit stops.


### PR DESCRIPTION
AllowedReverse and TransitionCostReverse.  These methods are used in bidirectional A* but could also be used in many to one paths which would be traversed in reverse.