### PR TITLE
Optimize TransitionCost where stopimpact == 0

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -275,20 +275,24 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
   } else if (node->intersection() == IntersectionType::kFalse) {
       return { 0.0f, 0.0f };
   } else {
-
     float penalty = 0.0f;
-    if (!pred.destonly() && edge->destonly())
+    if (!pred.destonly() && edge->destonly()) {
       penalty += destination_only_penalty_;
-
-    if (pred.use() != Use::kAlley && edge->use() == Use::kAlley)
+    }
+    if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
       penalty += alley_penalty_;
+    }
 
     // Transition cost = density * stopimpact * turncost + maneuverpenalty
+    float seconds = 0.0f;
     uint32_t idx = pred.opp_local_idx();
-    float seconds = trans_density_factor_[node->density()] *
-                    edge->stopimpact(idx) * TurnCost(edge->turntype(idx),
+    uint32_t stopimpact = edge->stopimpact(idx);
+    if (stopimpact > 0) {
+      seconds = trans_density_factor_[node->density()] * stopimpact *
+                TurnCost(edge->turntype(idx),
                          edge->edge_to_right(idx) && edge->edge_to_left(idx),
                          edge->drive_on_right());
+    }
     return (node->name_consistency(idx, edge->localedgeidx())) ?
               Cost(seconds + penalty, seconds) :
               Cost(seconds + maneuver_penalty_ + penalty, seconds);

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -263,7 +263,7 @@ BicycleCost::BicycleCost(const boost::property_tree::ptree& pt)
                                            kDefaultCountryCrossingPenalty);
 
   // Get the bicycle type - enter as string and convert to enum
-  std::string bicycle_type = pt.get("type", "Road");
+  std::string bicycle_type = pt.get("bicycle_type", "Road");
   if (bicycle_type == "Cross") {
     bicycletype_ = BicycleType::kCross;
   } else if (bicycle_type == "Hybrid" || bicycle_type == "City") {
@@ -447,20 +447,24 @@ Cost BicycleCost::TransitionCost(const baldr::DirectedEdge* edge,
   } else if (node->intersection() == IntersectionType::kFalse) {
       return { 0.0f, 0.0f };
   } else {
-
     float penalty = 0.0f;
-    if (!pred.destonly() && edge->destonly())
+    if (!pred.destonly() && edge->destonly()) {
       penalty += destination_only_penalty_;
-
-    if (pred.use() != Use::kAlley && edge->use() == Use::kAlley)
+    }
+    if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
       penalty += alley_penalty_;
+    }
 
     // Transition cost = density * stopimpact * turncost + maneuverpenalty
+    float seconds = 0.0f;
     uint32_t idx = pred.opp_local_idx();
-    float seconds = trans_density_factor_[node->density()] *
-                    edge->stopimpact(idx) * TurnCost(edge->turntype(idx),
+    uint32_t stopimpact = edge->stopimpact(idx);
+    if (stopimpact > 0) {
+      seconds = trans_density_factor_[node->density()] * stopimpact *
+                TurnCost(edge->turntype(idx),
                          edge->edge_to_right(idx) && edge->edge_to_left(idx),
                          edge->drive_on_right());
+    }
     return (node->name_consistency(idx, edge->localedgeidx())) ?
               Cost(seconds + penalty, seconds) :
               Cost(seconds + maneuver_penalty_ + penalty, seconds);


### PR DESCRIPTION
avoids other computations and improves performance by 1-2% on long routes.