### PR TITLE
Name consistency penalties were incorrectly applied. 

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -289,7 +289,7 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
   if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
     penalty += alley_penalty_;
   }
-  if (node->name_consistency(idx, edge->localedgeidx())) {
+  if (!node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
   }
 

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -478,7 +478,7 @@ Cost BicycleCost::TransitionCost(const baldr::DirectedEdge* edge,
   if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
     penalty += alley_penalty_;
   }
-  if (node->name_consistency(idx, edge->localedgeidx())) {
+  if (!node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
   }
 
@@ -523,7 +523,7 @@ Cost BicycleCost::TransitionCostReverse(const uint32_t idx,
   if (pred->use() != Use::kAlley && edge->use() == Use::kAlley) {
     penalty += alley_penalty_;
   }
-  if (node->name_consistency(idx, edge->localedgeidx())) {
+  if (!node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
   }
 


### PR DESCRIPTION
Need to apply penalty when names are not consistent! Last PR separated this out incorrectly