### PR TITLE
Fixed off by one in dynamic cost initialization.

### DIFF
--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -12,7 +12,7 @@ DynamicCost::DynamicCost(const boost::property_tree::ptree& pt,
       not_thru_distance_(5000.0f) {
   // Parse property tree to get hierarchy limits
   // TODO - get the number of levels
-  for (uint32_t level = 0; level <= 8; level++) {
+  for (uint32_t level = 0; level < 8; level++) {
     hierarchy_limits_.emplace_back(HierarchyLimits(pt, level));
   }
 }

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -12,7 +12,9 @@ DynamicCost::DynamicCost(const boost::property_tree::ptree& pt,
       not_thru_distance_(5000.0f) {
   // Parse property tree to get hierarchy limits
   // TODO - get the number of levels
-  for (uint32_t level = 0; level < 8; level++) {
+  uint32_t n_levels = sizeof(kDefaultMaxUpTransitions) /
+      sizeof(kDefaultMaxUpTransitions[0]);
+  for (uint32_t level = 0; level < n_levels; level++) {
     hierarchy_limits_.emplace_back(HierarchyLimits(pt, level));
   }
 }


### PR DESCRIPTION
Array sizes in sif/hierarchylimits.h have size 8. Maybe 8 should be replaced with something like sizeof(kDefaultMaxUpTransitions) / sizeof(kDefaultMaxUpTransitions[0]).

You can detect errors like this one by compiling with -fsanitize=address.