### PR TITLE
Add ferry_cost and use_ferry input option

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -20,8 +20,13 @@ constexpr float kDefaultGateCost                = 30.0f;  // Seconds
 constexpr float kDefaultGatePenalty             = 300.0f; // Seconds
 constexpr float kDefaultTollBoothCost           = 15.0f;  // Seconds
 constexpr float kDefaultTollBoothPenalty        = 0.0f;   // Seconds
+constexpr float kDefaultFerryCost               = 300.0f; // Seconds
 constexpr float kDefaultCountryCrossingCost     = 600.0f; // Seconds
 constexpr float kDefaultCountryCrossingPenalty  = 0.0f;   // Seconds
+
+// Maximum ferry penalty (when use_ferry == 0). Can't make this too large
+// since a ferry is sometimes required to complete a route.
+constexpr float kMaxFerryPenalty = 6.0f * 3600.0f; // 6 hours
 
 // Default turn costs
 constexpr float kTCStraight         = 0.5f;
@@ -41,7 +46,6 @@ constexpr float kLeftSideTurnCosts[]  = { kTCStraight, kTCSlight,
       kTCUnfavorable, kTCUnfavorableSharp, kTCReverse, kTCFavorableSharp,
       kTCFavorable, kTCSlight };
 }
-
 
 /**
  * Derived class providing dynamic edge costing for "direct" auto routes. This
@@ -179,6 +183,9 @@ class AutoCost : public DynamicCost {
   float gate_penalty_;              // Penalty (seconds) to go through gate
   float tollbooth_cost_;            // Cost (seconds) to go through toll booth
   float tollbooth_penalty_;         // Penalty (seconds) to go through a toll booth
+  float ferry_cost_;                // Cost (seconds) to enter a ferry
+  float ferry_penalty_;             // Penalty (seconds) to enter a ferry
+  float ferry_weight_;              // Weighting to apply to ferry edges
   float alley_penalty_;             // Penalty (seconds) to use a alley
   float country_crossing_cost_;     // Cost (seconds) to go through toll booth
   float country_crossing_penalty_;  // Penalty (seconds) to go across a country border
@@ -204,12 +211,33 @@ AutoCost::AutoCost(const boost::property_tree::ptree& pt)
   tollbooth_cost_ = pt.get<float>("toll_booth_cost", kDefaultTollBoothCost);
   tollbooth_penalty_ = pt.get<float>("toll_booth_penalty",
                                      kDefaultTollBoothPenalty);
-  alley_penalty_ = pt.get<float>("alley_penalty",
-                                 kDefaultAlleyPenalty);
+  alley_penalty_ = pt.get<float>("alley_penalty", kDefaultAlleyPenalty);
   country_crossing_cost_ = pt.get<float>("country_crossing_cost",
                                            kDefaultCountryCrossingCost);
   country_crossing_penalty_ = pt.get<float>("country_crossing_penalty",
                                            kDefaultCountryCrossingPenalty);
+
+  // Set the cost (seconds) to enter a ferry (only apply entering since
+  // a route must exit a ferry (except artificial test routes ending on
+  // a ferry!)
+  ferry_cost_ = pt.get<float>("ferry_cost", kDefaultFerryCost);
+
+  // Modify ferry penalty and edge weighting based on use_ferry factor
+  float use_ferry = pt.get<float>("use_ferry", 0.5f);
+  if (use_ferry < 0.5f) {
+    // Penalty goes from max at use_ferry = 0 to 0 at use_ferry = 0.5
+    float w = 1.0f - ((0.5f - use_ferry) * 2.0f);
+    ferry_penalty_ = static_cast<uint32_t>(kMaxFerryPenalty * (1.0f - w));
+
+    // Double the cost at use_ferry == 0, progress to 1.0 at use_ferry = 0.5
+    ferry_weight_ = 1.0f + w;
+  } else {
+    // Add a ferry weighting factor to influence cost along ferries to make
+    // them more favorable if desired rather than driving. No ferry penalty.
+    // Half the cost at use_ferry == 1, progress to 1.0 at use_ferry = 0.5
+    ferry_penalty_ = 0.0f;
+    ferry_weight_  = 1.0f - (use_ferry - 0.5f);
+  }
 
   // Create speed cost table
   speedfactor_[0] = kSecPerHour;  // TODO - what to make speed=0?
@@ -276,8 +304,10 @@ bool AutoCost::Allowed(const baldr::NodeInfo* node) const  {
 // Get the cost to traverse the edge in seconds
 Cost AutoCost::EdgeCost(const DirectedEdge* edge,
                         const uint32_t density) const {
+  float factor = (edge->use() == Use::kFerry) ?
+        ferry_weight_ : density_factor_[density];
   float sec = (edge->length() * speedfactor_[edge->speed()]);
-  return Cost(sec * density_factor_[density], sec);
+  return Cost(sec * factor, sec);
 }
 
 // Returns the time (in seconds) to make the transition from the predecessor
@@ -310,6 +340,10 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
   }
   if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
     penalty += alley_penalty_;
+  }
+  if (pred.use() != Use::kFerry && edge->use() == Use::kFerry) {
+    seconds += ferry_cost_;
+    penalty += ferry_penalty_;
   }
   if (!node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
@@ -366,6 +400,10 @@ Cost AutoCost::TransitionCostReverse(const uint32_t idx,
   }
   if (pred->use() != Use::kAlley && edge->use() == Use::kAlley) {
     penalty += alley_penalty_;
+  }
+  if (pred->use() != Use::kFerry && edge->use() == Use::kFerry) {
+    seconds += ferry_cost_;
+    penalty += ferry_penalty_;
   }
   if (!node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
@@ -461,7 +499,8 @@ AutoShorterCost::~AutoShorterCost() {
 // (in seconds) to traverse the edge.
 Cost AutoShorterCost::EdgeCost(const baldr::DirectedEdge* edge,
                                const uint32_t density) const {
-  return Cost(edge->length() * adjspeedfactor_[edge->speed()],
+  float factor = (edge->use() == Use::kFerry) ? ferry_weight_ : 1.0f;
+  return Cost(edge->length() * adjspeedfactor_[edge->speed()] * factor,
               edge->length() * speedfactor_[edge->speed()]);
 }
 

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -425,7 +425,7 @@ BicycleCost::BicycleCost(const boost::property_tree::ptree& pt)
   // Set the cost (seconds) to enter a ferry (only apply entering since
   // a route must exit a ferry (except artificial test routes ending on
   // a ferry!)
-  ferry_cost_ = kDefaultFerryCost;
+  ferry_cost_ = pt.get<float>("ferry_cost", kDefaultFerryCost);
 
   // Modify ferry penalty and edge weighting based on use_ferry factor
   float use_ferry = pt.get<float>("use_ferry", 0.5f);

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -16,8 +16,13 @@ constexpr float kDefaultDestinationOnlyPenalty  = 300.0f; // Seconds
 constexpr float kDefaultAlleyPenalty            = 30.0f;  // Seconds
 constexpr float kDefaultGateCost                = 30.0f;  // Seconds
 constexpr float kDefaultGatePenalty             = 300.0f; // Seconds
+constexpr float kDefaultFerryCost               = 300.0f; // Seconds
 constexpr float kDefaultCountryCrossingCost     = 600.0f; // Seconds
 constexpr float kDefaultCountryCrossingPenalty  = 0.0f;   // Seconds
+
+// Maximum ferry penalty (when use_ferry == 0). Can't make this too large
+// since a ferry is sometimes required to complete a route.
+constexpr float kMaxFerryPenalty = 8.0f * 3600.0f; // 8 hours
 
 // Default turn costs - modified by the stop impact.
 constexpr float kTCStraight         = 0.15f;
@@ -260,6 +265,9 @@ class BicycleCost : public DynamicCost {
   float gate_cost_;                 // Cost (seconds) to go through gate
   float gate_penalty_;              // Penalty (seconds) to go through gate
   float alley_penalty_;             // Penalty (seconds) to use a alley
+  float ferry_cost_;                // Cost (seconds) to exit a ferry
+  float ferry_penalty_;             // Penalty (seconds) to enter a ferry
+  float ferry_weight_;              // Weighting to apply to ferry edges
   float country_crossing_cost_;     // Cost (seconds) to go through toll booth
   float country_crossing_penalty_;  // Penalty (seconds) to go across a country border
 
@@ -414,6 +422,28 @@ BicycleCost::BicycleCost(const boost::property_tree::ptree& pt)
                  1.0f - (useroads_ - 0.5f) :
                  1.0f + (0.5f - useroads_) * 3.0f;
 
+  // Set the cost (seconds) to enter a ferry (only apply entering since
+  // a route must exit a ferry (except artificial test routes ending on
+  // a ferry!)
+  ferry_cost_ = kDefaultFerryCost;
+
+  // Modify ferry penalty and edge weighting based on use_ferry factor
+  float use_ferry = pt.get<float>("use_ferry", 0.5f);
+  if (use_ferry < 0.5f) {
+    // Penalty goes from max at use_ferry = 0 to 0 at use_ferry = 0.5
+    float w = 1.0f - ((0.5f - use_ferry) * 2.0f);
+    ferry_penalty_ = static_cast<uint32_t>(kMaxFerryPenalty * (1.0f - w));
+
+    // Double the cost at use_ferry == 0, progress to 1.0 at use_ferry = 0.5
+    ferry_weight_ = 1.0f + w;
+  } else {
+    // Add a ferry weighting factor to influence cost along ferries to make
+    // them more favorable if desired rather than driving. No ferry penalty.
+    // Half the cost at use_ferry == 1, progress to 1.0 at use_ferry = 0.5
+    ferry_penalty_ = 0.0f;
+    ferry_weight_  = 1.0f - (use_ferry - 0.5f);
+  }
+
   // Set the speed penalty threshold and factor. With useroads = 1 the
   // threshold is 70 kph (near 50 MPH).
   speed_penalty_threshold_ = kSpeedPenaltyThreshold +
@@ -486,6 +516,13 @@ Cost BicycleCost::EdgeCost(const baldr::DirectedEdge* edge,
   // Stairs/steps - use a high fixed cost so they are generally avoided.
   if (edge->use() == Use::kSteps) {
     return kBicycleStepsCost;
+  }
+
+  // Ferries are a special case - they use the ferry speed (stored on the edge)
+  if (edge->use() == Use::kFerry) {
+    // Compute elapsed time based on speed. Modulate cost with weighting factors.
+    float sec = (edge->length() * speedfactor_[edge->speed()]);
+    return { sec * ferry_weight_, sec };
   }
 
   // Update speed based on surface factor. Lower speed for rougher surfaces
@@ -579,6 +616,10 @@ Cost BicycleCost::TransitionCost(const baldr::DirectedEdge* edge,
   if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
     penalty += alley_penalty_;
   }
+  if ((pred.use() != Use::kFerry && edge->use() == Use::kFerry)) {
+    seconds += ferry_cost_;
+    penalty += ferry_penalty_;
+  }
   if (!node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
   }
@@ -629,6 +670,10 @@ Cost BicycleCost::TransitionCostReverse(const uint32_t idx,
   }
   if (pred->use() != Use::kAlley && edge->use() == Use::kAlley) {
     penalty += alley_penalty_;
+  }
+  if (pred->use() != Use::kFerry && edge->use() == Use::kFerry) {
+    seconds += ferry_cost_;
+    penalty += ferry_penalty_;
   }
   if (!node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -303,7 +303,9 @@ Cost PedestrianCost::TransitionCost(const baldr::DirectedEdge* edge,
     return { step_penalty_, 0.0f };
   }
 
-  // No cost from transit connection
+  // Nominal cost from transit connection
+  // TODO - validate if this is needed to prevent going into transit
+  // stops (without boarding a transit line) as a shortcut
   if (pred.use() == Use::kTransitConnection) {
     return { 20.0f, 0.0f };
   }

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -305,7 +305,7 @@ Cost PedestrianCost::TransitionCost(const baldr::DirectedEdge* edge,
 
   // No cost from transit connection
   if (pred.use() == Use::kTransitConnection) {
-    return { 0.0f, 0.0f };
+    return { 20.0f, 0.0f };
   }
 
   // Penalty through gates and border control.


### PR DESCRIPTION
ferry_cost is applied to both the elapsed time and cost for path determination.
When use_ferry is < 0.5 it adds penalties to try to avoid using ferries. 
When use_ferry > 0.5 there are no penalites and the cost along a ferry is reduced (based on length of the ferry) to try to favor using a ferry vs. auto (which is usually faster).
Ferry logic is also applied to bicycle costing - when on a ferry the elapsed time and cost is based on the ferry speed (not the bicycling speed).