### PR TITLE
Gk

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -86,13 +86,13 @@ class AutoCost : public DynamicCost {
    * @param  edge     Pointer to a directed edge.
    * @param  pred     Predecessor edge information.
    * @param  tile     current tile
-   * @param  graphid  graphid that we care about
+   * @param  edgeid   edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& graphid) const;
+                       const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -104,7 +104,7 @@ class AutoCost : public DynamicCost {
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
    * @param  tile           current tile
-   * @param  graphid        graphid that we care about
+   * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
@@ -112,7 +112,7 @@ class AutoCost : public DynamicCost {
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
-                 const baldr::GraphId& graphid) const;
+                 const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -278,7 +278,7 @@ bool AutoCost::AllowMultiPass() const {
 bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& graphid) const {
+                       const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -299,7 +299,7 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& graphid) const {
+               const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -551,13 +551,13 @@ class BusCost : public AutoCost {
    * @param  edge     Pointer to a directed edge.
    * @param  pred     Predecessor edge information.
    * @param  tile     current tile
-   * @param  graphid  graphid that we care about
+   * @param  edgeid   edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& graphid) const;
+                       const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -568,14 +568,14 @@ class BusCost : public AutoCost {
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
    * @param  tile           current tile
-   * @param  graphid        graphid that we care about
+   * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
-                 const baldr::GraphId& graphid) const;
+                 const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -609,7 +609,7 @@ BusCost::~BusCost() {
 bool BusCost::Allowed(const baldr::DirectedEdge* edge,
                       const EdgeLabel& pred,
                       const baldr::GraphTile*& tile,
-                      const baldr::GraphId& graphid) const {
+                      const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -629,7 +629,7 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& graphid) const {
+               const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -83,32 +83,36 @@ class AutoCost : public DynamicCost {
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
    * based on other parameters.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  edge     Pointer to a directed edge.
+   * @param  pred     Predecessor edge information.
+   * @param  tile     current tile
+   * @param  graphid  graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
-                       const std::vector<baldr::AccessRestriction>& restrictions) const;
+                       const baldr::GraphTile*& tile,
+                       const baldr::GraphId& graphid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
    * (from destination towards origin). Both opposing edges are
    * provided.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  opp_edge  Pointer to the opposing directed edge.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  opp_edge       Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  tile           current tile
+   * @param  graphid        graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
-                 const std::vector<baldr::AccessRestriction>& restrictions) const;
+                 const baldr::GraphTile*& tile,
+                 const baldr::GraphId& graphid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -273,7 +277,10 @@ bool AutoCost::AllowMultiPass() const {
 // not_thru due to hierarchy transitions
 bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
-                       const std::vector<baldr::AccessRestriction>& restrictions) const {
+                       const baldr::GraphTile*& tile,
+                       const baldr::GraphId& graphid) const {
+  // TODO - obtain and check the access restrictions.
+
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(edge->forwardaccess() & kAutoAccess) ||
@@ -291,7 +298,10 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
-               const std::vector<baldr::AccessRestriction>& restrictions) const {
+               const baldr::GraphTile*& tile,
+               const baldr::GraphId& graphid) const {
+  // TODO - obtain and check the access restrictions.
+
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(opp_edge->forwardaccess() & kAutoAccess) ||
@@ -538,30 +548,34 @@ class BusCost : public AutoCost {
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
    * based on other parameters.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  edge     Pointer to a directed edge.
+   * @param  pred     Predecessor edge information.
+   * @param  tile     current tile
+   * @param  graphid  graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
-                       const std::vector<baldr::AccessRestriction>& restrictions) const;
+                       const baldr::GraphTile*& tile,
+                       const baldr::GraphId& graphid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
    * (from destination towards origin). Both opposing edges are
    * provided.
-   * @param  edge  Pointer to a directed edge.
-   * @param  opp_edge  Pointer to the opposing directed edge.
+   * @param  edge           Pointer to a directed edge.
+   * @param  opp_edge       Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  tile           current tile
+   * @param  graphid        graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
-                 const std::vector<baldr::AccessRestriction>& restrictions) const;
+                 const baldr::GraphTile*& tile,
+                 const baldr::GraphId& graphid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -594,7 +608,10 @@ BusCost::~BusCost() {
 // not_thru due to hierarchy transitions
 bool BusCost::Allowed(const baldr::DirectedEdge* edge,
                       const EdgeLabel& pred,
-                      const std::vector<baldr::AccessRestriction>& restrictions) const {
+                      const baldr::GraphTile*& tile,
+                      const baldr::GraphId& graphid) const {
+  // TODO - obtain and check the access restrictions.
+
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(edge->forwardaccess() & kBusAccess) ||
@@ -611,7 +628,10 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
 bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
-               const std::vector<baldr::AccessRestriction>& restrictions) const {
+               const baldr::GraphTile*& tile,
+               const baldr::GraphId& graphid) const {
+  // TODO - obtain and check the access restrictions.
+
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(opp_edge->forwardaccess() & kBusAccess) ||

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -4,6 +4,7 @@
 #include <valhalla/midgard/constants.h>
 #include <valhalla/baldr/directededge.h>
 #include <valhalla/baldr/nodeinfo.h>
+#include <valhalla/baldr/accessrestriction.h>
 #include <valhalla/midgard/logging.h>
 
 using namespace valhalla::baldr;
@@ -80,10 +81,12 @@ class AutoCost : public DynamicCost {
    * based on other parameters.
    * @param  edge  Pointer to a directed edge.
    * @param  pred  Predecessor edge information.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
-                       const EdgeLabel& pred) const;
+                       const EdgeLabel& pred,
+                       const std::vector<baldr::AccessRestriction>& restrictions) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -94,12 +97,14 @@ class AutoCost : public DynamicCost {
    * @param  opp_edge  Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge) const;
+                 const baldr::DirectedEdge* opp_pred_edge,
+                 const std::vector<baldr::AccessRestriction>& restrictions) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -239,7 +244,8 @@ bool AutoCost::AllowMultiPass() const {
 // Check if access is allowed on the specified edge. Not worth checking
 // not_thru due to hierarchy transitions
 bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
-                       const EdgeLabel& pred) const {
+                       const EdgeLabel& pred,
+                       const std::vector<baldr::AccessRestriction>& restrictions) const {
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(edge->forwardaccess() & kAutoAccess) ||
@@ -256,7 +262,8 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
 bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge) const {
+               const baldr::DirectedEdge* opp_pred_edge,
+               const std::vector<baldr::AccessRestriction>& restrictions) const {
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(opp_edge->forwardaccess() & kAutoAccess) ||
@@ -495,10 +502,12 @@ class BusCost : public AutoCost {
    * based on other parameters.
    * @param  edge  Pointer to a directed edge.
    * @param  pred  Predecessor edge information.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
-                       const EdgeLabel& pred) const;
+                       const EdgeLabel& pred,
+                       const std::vector<baldr::AccessRestriction>& restrictions) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -508,11 +517,13 @@ class BusCost : public AutoCost {
    * @param  opp_edge  Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge) const;
+                 const baldr::DirectedEdge* opp_pred_edge,
+                 const std::vector<baldr::AccessRestriction>& restrictions) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -544,7 +555,8 @@ BusCost::~BusCost() {
 // Check if access is allowed on the specified edge. Not worth checking
 // not_thru due to hierarchy transitions
 bool BusCost::Allowed(const baldr::DirectedEdge* edge,
-                       const EdgeLabel& pred) const {
+                      const EdgeLabel& pred,
+                      const std::vector<baldr::AccessRestriction>& restrictions) const {
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(edge->forwardaccess() & kBusAccess) ||
@@ -560,7 +572,8 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
 // destination towards origin). Both opposing edges are provided.
 bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge) const {
+               const baldr::DirectedEdge* opp_pred_edge,
+               const std::vector<baldr::AccessRestriction>& restrictions) const {
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(opp_edge->forwardaccess() & kBusAccess) ||

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -2,6 +2,7 @@
 #include <valhalla/baldr/directededge.h>
 #include <valhalla/baldr/nodeinfo.h>
 #include <valhalla/midgard/constants.h>
+#include <valhalla/baldr/accessrestriction.h>
 #include <valhalla/midgard/logging.h>
 
 using namespace valhalla::baldr;
@@ -167,10 +168,12 @@ class BicycleCost : public DynamicCost {
    * based on other parameters.
    * @param  edge  Pointer to a directed edge.
    * @param  pred  Predecessor edge information.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
-                       const EdgeLabel& pred) const;
+                       const EdgeLabel& pred,
+                       const std::vector<baldr::AccessRestriction>& restrictions) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -181,12 +184,14 @@ class BicycleCost : public DynamicCost {
    * @param  opp_edge  Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge) const;
+                 const baldr::DirectedEdge* opp_pred_edge,
+                 const std::vector<baldr::AccessRestriction>& restrictions) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -440,7 +445,8 @@ BicycleCost::~BicycleCost() {
 
 // Check if access is allowed on the specified edge.
 bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
-                          const EdgeLabel& pred) const {
+                          const EdgeLabel& pred,
+                          const std::vector<baldr::AccessRestriction>& restrictions) const {
   // Check bicycle access and turn restrictions. Bicycles should obey
   // vehicular turn restrictions. Disallow Uturns. Do not allow entering
   // not-thru edges except near the destination. Skip impassable edges.
@@ -460,7 +466,8 @@ bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
 bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge) const {
+               const baldr::DirectedEdge* opp_pred_edge,
+               const std::vector<baldr::AccessRestriction>& restrictions) const {
   // Check access, U-turn, and simple turn restriction.
   // Check if edge is not-thru (no need to check distance from destination
   // since the search is heading out of any not_thru regions)

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -174,13 +174,13 @@ class BicycleCost : public DynamicCost {
    * @param  edge     Pointer to a directed edge.
    * @param  pred     Predecessor edge information.
    * @param  tile     current tile
-   * @param  graphid  graphid that we care about
+   * @param  edgeid   edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& graphid) const;
+                       const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -192,7 +192,7 @@ class BicycleCost : public DynamicCost {
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
    * @param  tile           current tile
-   * @param  graphid        graphid that we care about
+   * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
@@ -200,7 +200,7 @@ class BicycleCost : public DynamicCost {
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
-                 const baldr::GraphId& graphid) const;
+                 const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -481,7 +481,7 @@ BicycleCost::~BicycleCost() {
 bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
                           const EdgeLabel& pred,
                           const baldr::GraphTile*& tile,
-                          const baldr::GraphId& graphid) const {
+                          const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   // Check bicycle access and turn restrictions. Bicycles should obey
@@ -505,7 +505,7 @@ bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& graphid) const {
+               const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -171,32 +171,36 @@ class BicycleCost : public DynamicCost {
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
    * based on other parameters.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  edge     Pointer to a directed edge.
+   * @param  pred     Predecessor edge information.
+   * @param  tile     current tile
+   * @param  graphid  graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
-                       const std::vector<baldr::AccessRestriction>& restrictions) const;
+                       const baldr::GraphTile*& tile,
+                       const baldr::GraphId& graphid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
    * (from destination towards origin). Both opposing edges are
    * provided.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  opp_edge  Pointer to the opposing directed edge.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  opp_edge       Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  tile           current tile
+   * @param  graphid        graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
-                 const std::vector<baldr::AccessRestriction>& restrictions) const;
+                 const baldr::GraphTile*& tile,
+                 const baldr::GraphId& graphid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -476,7 +480,10 @@ BicycleCost::~BicycleCost() {
 // Check if access is allowed on the specified edge.
 bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
                           const EdgeLabel& pred,
-                          const std::vector<baldr::AccessRestriction>& restrictions) const {
+                          const baldr::GraphTile*& tile,
+                          const baldr::GraphId& graphid) const {
+  // TODO - obtain and check the access restrictions.
+
   // Check bicycle access and turn restrictions. Bicycles should obey
   // vehicular turn restrictions. Disallow Uturns. Do not allow entering
   // not-thru edges except near the destination. Skip impassable edges.
@@ -497,7 +504,10 @@ bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
-               const std::vector<baldr::AccessRestriction>& restrictions) const {
+               const baldr::GraphTile*& tile,
+               const baldr::GraphId& graphid) const {
+  // TODO - obtain and check the access restrictions.
+
   // Check access, U-turn, and simple turn restriction.
   // Check if edge is not-thru (no need to check distance from destination
   // since the search is heading out of any not_thru regions)

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -68,6 +68,11 @@ Cost DynamicCost::TransferCost(const TransitTransfer* transfer) const {
   return { 0.0f, 0.0f };
 }
 
+// Returns the default transfer cost between 2 transit stops.
+Cost DynamicCost::DefaultTransferCost() const {
+  return { 0.0f, 0.0f };
+}
+
 // Get the general unit size that can be considered as equal for sorting
 // purposes. Defaults to 1 (second).
 uint32_t DynamicCost::UnitSize() const {

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -1,5 +1,6 @@
 #include "sif/pedestriancost.h"
 
+#include <valhalla/baldr/accessrestriction.h>
 #include <valhalla/midgard/constants.h>
 #include <valhalla/midgard/logging.h>
 
@@ -63,10 +64,12 @@ class PedestrianCost : public DynamicCost {
    * based on other parameters.
    * @param  edge  Pointer to a directed edge.
    * @param  pred  Predecessor edge information.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
-                       const EdgeLabel& pred) const;
+                       const EdgeLabel& pred,
+                       const std::vector<baldr::AccessRestriction>& restrictions) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -77,12 +80,14 @@ class PedestrianCost : public DynamicCost {
    * @param  opp_edge  Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge) const;
+                 const baldr::DirectedEdge* opp_pred_edge,
+                 const std::vector<baldr::AccessRestriction>& restrictions) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -224,7 +229,8 @@ void PedestrianCost::UseMaxModeDistance() {
 // destination. Do not allow if surface is impassable. Disallow edges
 // where max. walking distance will be exceeded.
 bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
-                             const EdgeLabel& pred) const {
+                             const EdgeLabel& pred,
+                             const std::vector<baldr::AccessRestriction>& restrictions) const {
   // Disallow if no pedestrian access, surface marked as impassible,
   // edge is not-thru and we are far from destination, or if max
   // walking distance is exceeded.
@@ -253,7 +259,8 @@ bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
 bool PedestrianCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge) const {
+               const baldr::DirectedEdge* opp_pred_edge,
+               const std::vector<baldr::AccessRestriction>& restrictions) const {
   // Disallow if no pedestrian access, surface marked as impassible, Uturn,
   // or edge is not-thru (no need to check distance from destination since
   // the search is heading out of any not_thru regions). Do not check max

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -66,13 +66,13 @@ class PedestrianCost : public DynamicCost {
    * @param  edge     Pointer to a directed edge.
    * @param  pred     Predecessor edge information.
    * @param  tile     current tile
-   * @param  graphid  graphid that we care about
+   * @param  edgeid   edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& graphid) const;
+                       const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -84,7 +84,7 @@ class PedestrianCost : public DynamicCost {
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
    * @param  tile           current tile
-   * @param  graphid        graphid that we care about
+   * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
@@ -92,7 +92,7 @@ class PedestrianCost : public DynamicCost {
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
-                 const baldr::GraphId& graphid) const;
+                 const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -239,7 +239,7 @@ void PedestrianCost::UseMaxModeDistance() {
 bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
                              const EdgeLabel& pred,
                              const baldr::GraphTile*& tile,
-                             const baldr::GraphId& graphid) const {
+                             const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   // Disallow if no pedestrian access, surface marked as impassible,
@@ -272,7 +272,7 @@ bool PedestrianCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& graphid) const {
+               const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   // Disallow if no pedestrian access, surface marked as impassible, Uturn,

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -63,32 +63,36 @@ class PedestrianCost : public DynamicCost {
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
    * based on other parameters.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  edge     Pointer to a directed edge.
+   * @param  pred     Predecessor edge information.
+   * @param  tile     current tile
+   * @param  graphid  graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
-                       const std::vector<baldr::AccessRestriction>& restrictions) const;
+                       const baldr::GraphTile*& tile,
+                       const baldr::GraphId& graphid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
    * (from destination towards origin). Both opposing edges are
    * provided.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  opp_edge  Pointer to the opposing directed edge.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  opp_edge       Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  tile           current tile
+   * @param  graphid        graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
-                 const std::vector<baldr::AccessRestriction>& restrictions) const;
+                 const baldr::GraphTile*& tile,
+                 const baldr::GraphId& graphid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -234,7 +238,10 @@ void PedestrianCost::UseMaxModeDistance() {
 // where max. walking distance will be exceeded.
 bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
                              const EdgeLabel& pred,
-                             const std::vector<baldr::AccessRestriction>& restrictions) const {
+                             const baldr::GraphTile*& tile,
+                             const baldr::GraphId& graphid) const {
+  // TODO - obtain and check the access restrictions.
+
   // Disallow if no pedestrian access, surface marked as impassible,
   // edge is not-thru and we are far from destination, or if max
   // walking distance is exceeded.
@@ -264,7 +271,10 @@ bool PedestrianCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
-               const std::vector<baldr::AccessRestriction>& restrictions) const {
+               const baldr::GraphTile*& tile,
+               const baldr::GraphId& graphid) const {
+  // TODO - obtain and check the access restrictions.
+
   // Disallow if no pedestrian access, surface marked as impassible, Uturn,
   // or edge is not-thru (no need to check distance from destination since
   // the search is heading out of any not_thru regions). Do not check max

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -17,8 +17,8 @@ constexpr float kDefaultBusFactor   = 1.0f;
 constexpr float kDefaultBusPenalty  = 0.0f;
 constexpr float kDefaultRailFactor  = 1.0f;
 constexpr float kDefaultRailPenalty = 0.0f;
-constexpr float kDefaultTransferCost = 30.0f;
-constexpr float kDefaultTransferPenalty = 300.0f;  // 10 minute default
+constexpr float kDefaultTransferCost = 60.0f;
+constexpr float kDefaultTransferPenalty = 300.0f;  // 5 minute default
 
 // User propensity to use buses. Range of values from 0 (avoid buses) to
 // 1 (totally comfortable riding on buses).

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -55,32 +55,36 @@ class TransitCost : public DynamicCost {
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
    * based on other parameters.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  edge     Pointer to a directed edge.
+   * @param  pred     Predecessor edge information.
+   * @param  tile     current tile
+   * @param  graphid  graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
-                       const std::vector<baldr::AccessRestriction>& restrictions) const;
+                       const baldr::GraphTile*& tile,
+                       const baldr::GraphId& graphid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
    * (from destination towards origin). Both opposing edges are
    * provided.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  opp_edge  Pointer to the opposing directed edge.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  opp_edge       Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  tile           current tile
+   * @param  graphid        graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
-                 const std::vector<baldr::AccessRestriction>& restrictions) const;
+                 const baldr::GraphTile*& tile,
+                 const baldr::GraphId& graphid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -239,7 +243,10 @@ TransitCost::~TransitCost() {
 // Check if access is allowed on the specified edge.
 bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
                           const EdgeLabel& pred,
-                          const std::vector<baldr::AccessRestriction>& restrictions) const {
+                          const baldr::GraphTile*& tile,
+                          const baldr::GraphId& graphid) const {
+  // TODO - obtain and check the access restrictions.
+
   if (edge->use() == Use::kBus) {
     return (use_bus_ > 0.0f) ? true : false;
   } else if (edge->use() == Use::kRail) {
@@ -254,7 +261,10 @@ bool TransitCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
-               const std::vector<baldr::AccessRestriction>& restrictions) const {
+               const baldr::GraphTile*& tile,
+               const baldr::GraphId& graphid) const {
+  // TODO - obtain and check the access restrictions.
+
   // This method should not be called since time based routes do not use
   // bidirectional A*
   return false;

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -17,8 +17,8 @@ constexpr float kDefaultBusFactor   = 1.0f;
 constexpr float kDefaultBusPenalty  = 0.0f;
 constexpr float kDefaultRailFactor  = 1.0f;
 constexpr float kDefaultRailPenalty = 0.0f;
-constexpr float kDefaultTransferCost = 60.0f;
-constexpr float kDefaultTransferPenalty = 600.0f;  // 10 minute default
+constexpr float kDefaultTransferCost = 30.0f;
+constexpr float kDefaultTransferPenalty = 300.0f;  // 10 minute default
 
 // User propensity to use buses. Range of values from 0 (avoid buses) to
 // 1 (totally comfortable riding on buses).
@@ -314,13 +314,13 @@ Cost TransitCost::TransitionCost(const baldr::DirectedEdge* edge,
 Cost TransitCost::TransferCost(const TransitTransfer* transfer) const {
   if (transfer == nullptr) {
     // No transfer record exists - use defaults
-    return { transfer_cost_ +  transfer_penalty_, transfer_cost_  };
+    return { transfer_cost_ + (transfer_penalty_ * transfer_factor_), transfer_cost_ };
   }
   switch (transfer->type()) {
   case TransferType::kRecommended:
-    return { 15.0f + (transfer_penalty_ * transfer_factor_), 15.0f };
+    return { transfer_cost_ + (transfer_penalty_ * transfer_factor_), transfer_cost_ };
   case TransferType::kTimed:
-    return { 15.0f + (transfer_penalty_ * transfer_factor_), 15.0f };
+    return { transfer_cost_ + (transfer_penalty_ * transfer_factor_), transfer_cost_ };
   case TransferType::kMinTime:
     return { static_cast<float>(transfer->mintime() + (transfer_penalty_ * transfer_factor_)),
              static_cast<float>(transfer->mintime()) };
@@ -331,7 +331,7 @@ Cost TransitCost::TransferCost(const TransitTransfer* transfer) const {
 
 // Returns the default transfer cost between 2 transit lines.
 Cost TransitCost::DefaultTransferCost() const {
-  return { (transfer_penalty_ * transfer_factor_), transfer_cost_ };
+  return { transfer_cost_ + (transfer_penalty_ * transfer_factor_), transfer_cost_ };
 }
 
 // Get the cost factor for A* heuristics. This factor is multiplied

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -1,5 +1,6 @@
 #include "sif/transitcost.h"
 
+#include <valhalla/baldr/accessrestriction.h>
 #include <valhalla/midgard/constants.h>
 #include <valhalla/midgard/logging.h>
 
@@ -12,15 +13,24 @@ namespace sif {
 namespace {
 constexpr uint32_t kUnitSize = 1;
 
-// Default neither favors nor avoids buses vs rail/subway
-constexpr bool  kDefaultAllowBus    = true;
-constexpr bool  kDefaultAllowRail   = true;
 constexpr float kDefaultBusFactor   = 1.0f;
 constexpr float kDefaultBusPenalty  = 0.0f;
 constexpr float kDefaultRailFactor  = 1.0f;
 constexpr float kDefaultRailPenalty = 0.0f;
 constexpr float kDefaultTransferCost = 60.0f;
 constexpr float kDefaultTransferPenalty = 600.0f;  // 5 minute default
+
+// User propensity to use buses. Range of values from 0 (avoid buses) to
+// 1 (totally comfortable riding on buses).
+constexpr float kDefaultUseBusFactor = 0.5f;
+
+// User propensity to use rail. Range of values from 0 (avoid rail) to
+// 1 (totally comfortable riding on rail).
+constexpr float kDefaultUseRailFactor = 0.5f;
+
+// User propensity to use/allow transfers. Range of values from 0
+// (avoid transfers) to 1 (totally comfortable with transfers).
+constexpr float kDefaultUseTransfersFactor = 0.5f;
 
 Cost kImpossibleCost = { 10000000.0f, 10000000.0f };
 }
@@ -47,10 +57,12 @@ class TransitCost : public DynamicCost {
    * based on other parameters.
    * @param  edge  Pointer to a directed edge.
    * @param  pred  Predecessor edge information.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
-                       const EdgeLabel& pred) const;
+                       const EdgeLabel& pred,
+                       const std::vector<baldr::AccessRestriction>& restrictions) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -61,12 +73,14 @@ class TransitCost : public DynamicCost {
    * @param  opp_edge  Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge) const;
+                 const baldr::DirectedEdge* opp_pred_edge,
+                 const std::vector<baldr::AccessRestriction>& restrictions) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -148,12 +162,24 @@ class TransitCost : public DynamicCost {
   }
 
  protected:
-  bool allow_bus_;
-  bool allow_rail_;
+
+  // A measure of willingness to ride on buses or rail. Ranges from 0-1 with
+  // 0 being not willing at all and 1 being totally comfortable with taking
+  // this transportation. These factors determine how much rail or buses are
+  // preferred over each other (if at all).
+  float use_bus_;
+  float use_rail_;
   float bus_factor_;
-  float bus_penalty_;
   float rail_factor_;
+
+  float bus_penalty_;
   float rail_penalty_;
+
+  // A measure of willingness to make transfers. Ranges from 0-1 with
+  // 0 being not willing at all and 1 being totally comfortable.
+  float use_transfers_;
+  float transfer_factor_;
+
   float transfer_cost_;     // Transfer cost when no transfer record exists
   float transfer_penalty_;  // Transfer penalty
 };
@@ -162,12 +188,43 @@ class TransitCost : public DynamicCost {
 // not present, set the default.
 TransitCost::TransitCost(const boost::property_tree::ptree& pt)
     : DynamicCost(pt, TravelMode::kPublicTransit) {
-  allow_bus_    = pt.get<bool>("allow_bus",  kDefaultAllowBus);
-  allow_rail_   = pt.get<bool>("allow_rail", kDefaultAllowRail);
-  bus_factor_   = pt.get<float>("bus_factor", kDefaultBusFactor);
-  bus_penalty_  = pt.get<float>("bus_penalty", kDefaultBusPenalty);
-  rail_factor_  = pt.get<float>("rail_factor", kDefaultRailFactor);
-  rail_penalty_ = pt.get<float>("rail_penalty", kDefaultRailPenalty);
+
+  // Willingness to use buses. Make sure this is within range [0, 1].
+  use_bus_ = pt.get<float>("use_bus", kDefaultUseBusFactor);
+  if (use_bus_ < 0.0f || use_bus_ > 1.0f) {
+    LOG_WARN("Outside valid use_bus factor range " +
+              std::to_string(use_bus_) + ": using default");
+  }
+
+  // Willingness to use rail. Make sure this is within range [0, 1].
+  use_rail_ = pt.get<float>("use_rail", kDefaultUseRailFactor);
+  if (use_rail_ < 0.0f || use_rail_ > 1.0f) {
+    LOG_WARN("Outside valid use_rail factor range " +
+              std::to_string(use_rail_) + ": using default");
+  }
+
+  // Willingness to make transfers. Make sure this is within range [0, 1].
+  use_transfers_ = pt.get<float>("use_transfers", kDefaultUseTransfersFactor);
+  if (use_transfers_ < 0.0f || use_transfers_ > 1.0f) {
+    LOG_WARN("Outside valid use_transfers factor range " +
+              std::to_string(use_transfers_) + ": using default");
+  }
+
+  // Set the factors. The factors above 0.5 start to reduce the weight
+  // for this mode while factors below 0.5 start to increase the weight for
+  // this mode.
+  bus_factor_ = (use_bus_ >= 0.5f) ?
+                 1.0f - (use_bus_ - 0.5f) :
+                 1.0f + (0.5f - use_bus_) * 5.0f;
+
+  rail_factor_ = (use_rail_ >= 0.5f) ?
+                 1.0f - (use_rail_ - 0.5f) :
+                 1.0f + (0.5f - use_rail_) * 5.0f;
+
+  transfer_factor_ = (use_transfers_ >= 0.5f) ?
+                 1.0f - (use_transfers_ - 0.5f) :
+                 1.0f + (0.5f - use_transfers_);
+
   transfer_cost_ = pt.get<float>("transfer_cost", kDefaultTransferCost);
   transfer_penalty_ = pt.get<float>("transfer_penalty", kDefaultTransferPenalty);
 }
@@ -178,11 +235,12 @@ TransitCost::~TransitCost() {
 
 // Check if access is allowed on the specified edge.
 bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
-                          const EdgeLabel& pred) const {
+                          const EdgeLabel& pred,
+                          const std::vector<baldr::AccessRestriction>& restrictions) const {
   if (edge->use() == Use::kBus) {
-    return allow_bus_;
+    return (use_bus_ > 0.0f) ? true : false;
   } else if (edge->use() == Use::kRail) {
-    return allow_rail_;
+    return (use_rail_ > 0.0f) ? true : false;
   }
   return true;
 }
@@ -192,7 +250,8 @@ bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
 bool TransitCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge) const {
+               const baldr::DirectedEdge* opp_pred_edge,
+               const std::vector<baldr::AccessRestriction>& restrictions) const {
   // This method should not be called since time based routes do not use
   // bidirectional A*
   return false;
@@ -225,9 +284,9 @@ Cost TransitCost::EdgeCost(const baldr::DirectedEdge* edge,
   // Cost is modulated by mode-based weight factor
   float weight = 1.0f;
   if (edge->use() == Use::kBus) {
-    weight = bus_factor_;
+    weight *= bus_factor_;
   } else if (edge->use() == Use::kRail) {
-    weight = rail_factor_;
+    weight *= rail_factor_;
   }
   return { elapsedtime * weight, elapsedtime };
 }
@@ -240,9 +299,9 @@ Cost TransitCost::TransitionCost(const baldr::DirectedEdge* edge,
     // Apply any mode-based penalties when boarding transit
     // Do we want any time cost to board?
     if (edge->use() == Use::kBus) {
-      return { bus_penalty_, 0.0f };
+      return { (0.5f + bus_factor_), 0.0f };
     } else if (edge->use() == Use::kRail) {
-      return { rail_penalty_, 0.0f };
+      return { (0.5f + rail_factor_), 0.0f };
     }
   }
   return { 0.0f, 0.0f };
@@ -256,11 +315,11 @@ Cost TransitCost::TransferCost(const TransitTransfer* transfer) const {
   }
   switch (transfer->type()) {
   case TransferType::kRecommended:
-    return { 15.0f + transfer_penalty_, 15.0f };
+    return { 15.0f + (transfer_penalty_ * transfer_factor_), 15.0f };
   case TransferType::kTimed:
-    return { 15.0f + transfer_penalty_, 15.0f };
+    return { 15.0f + (transfer_penalty_ * transfer_factor_), 15.0f };
   case TransferType::kMinTime:
-    return { static_cast<float>(transfer->mintime() + transfer_penalty_),
+    return { static_cast<float>(transfer->mintime() + (transfer_penalty_ * transfer_factor_)),
              static_cast<float>(transfer->mintime()) };
   case TransferType::kNotPossible:
     return kImpossibleCost;

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -58,13 +58,13 @@ class TransitCost : public DynamicCost {
    * @param  edge     Pointer to a directed edge.
    * @param  pred     Predecessor edge information.
    * @param  tile     current tile
-   * @param  graphid  graphid that we care about
+   * @param  edgeid   edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& graphid) const;
+                       const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -76,7 +76,7 @@ class TransitCost : public DynamicCost {
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
    * @param  tile           current tile
-   * @param  graphid        graphid that we care about
+   * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
@@ -84,7 +84,7 @@ class TransitCost : public DynamicCost {
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
-                 const baldr::GraphId& graphid) const;
+                 const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -244,7 +244,7 @@ TransitCost::~TransitCost() {
 bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
                           const EdgeLabel& pred,
                           const baldr::GraphTile*& tile,
-                          const baldr::GraphId& graphid) const {
+                          const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   if (edge->use() == Use::kBus) {
@@ -262,7 +262,7 @@ bool TransitCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& graphid) const {
+               const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   // This method should not be called since time based routes do not use

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -36,7 +36,7 @@ constexpr float kTCUnfavorableSharp = 3.5f;
 constexpr float kTCReverse          = 5.0f;
 
 // Default truck attributes
-constexpr float kDefaultTruckWeight   = 36.29f; // Metric Tons (80,000 lbs)
+constexpr float kDefaultTruckWeight   = 21.77f; // Metric Tons (48,000 lbs)
 constexpr float kDefaultTruckAxleLoad = 9.07f;  // Metric Tons (20,000 lbs)
 constexpr float kDefaultTruckHeight   = 4.11f;  // Meters (13 feet 6 inches)
 constexpr float kDefaultTruckWidth    = 2.6f;   // Meters (102.36 inches)

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -294,45 +294,42 @@ bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
     return false;
   }
 
-  if ((edge->access_restriction() & kTruckAccess) &&
-       restrictions.size()) {
+  for (const auto& restriction : restrictions ) {
+    // TODO:  Need to handle restictions that take place only at certain
+    // times.  Currently, we only support kAllDaysOfWeek;
+    if (restriction.modes() & kTruckAccess) {
 
-    for (const auto& restriction : restrictions ) {
-      // TODO:  Need to handle restictions that take place only at certain
-      // times.  Currently, we only support kAllDaysOfWeek;
-      if (restriction.modes() & kTruckAccess) {
-
-        switch (restriction.type()) {
-          case AccessType::kHazmat:
-            if (hazmat_ != restriction.value())
-              return false;
-            break;
-          case AccessType::kMaxAxleLoad:
-            if (axle_load_ > static_cast<float>(restriction.value()*0.01))
-              return false;
-            break;
-          case AccessType::kMaxHeight:
-            if (height_ > static_cast<float>(restriction.value()*0.01))
-              return false;
-            break;
-          case AccessType::kMaxLength:
-            if (length_ > static_cast<float>(restriction.value()*0.01))
-              return false;
-            break;
-          case AccessType::kMaxWeight:
-            if (weight_ > static_cast<float>(restriction.value()*0.01))
-              return false;
-            break;
-          case AccessType::kMaxWidth:
-            if (width_ > static_cast<float>(restriction.value()*0.01))
-              return false;
-            break;
-          default:
-            break;
-        }
+      switch (restriction.type()) {
+        case AccessType::kHazmat:
+          if (hazmat_ != restriction.value())
+            return false;
+          break;
+        case AccessType::kMaxAxleLoad:
+          if (axle_load_ > static_cast<float>(restriction.value()*0.01))
+            return false;
+          break;
+        case AccessType::kMaxHeight:
+          if (height_ > static_cast<float>(restriction.value()*0.01))
+            return false;
+          break;
+        case AccessType::kMaxLength:
+          if (length_ > static_cast<float>(restriction.value()*0.01))
+            return false;
+          break;
+        case AccessType::kMaxWeight:
+          if (weight_ > static_cast<float>(restriction.value()*0.01))
+            return false;
+          break;
+        case AccessType::kMaxWidth:
+          if (width_ > static_cast<float>(restriction.value()*0.01))
+            return false;
+          break;
+        default:
+          break;
       }
     }
   }
+
   return true;
 }
 

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -102,13 +102,13 @@ class TruckCost : public DynamicCost {
    * @param  edge     Pointer to a directed edge.
    * @param  pred     Predecessor edge information.
    * @param  tile     current tile
-   * @param  graphid  graphid that we care about
+   * @param  edgeid   edgeid that we care about
    * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& graphid) const;
+                       const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -120,7 +120,7 @@ class TruckCost : public DynamicCost {
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
    * @param  tile           current tile
-   * @param  graphid        graphid that we care about
+   * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
@@ -128,7 +128,7 @@ class TruckCost : public DynamicCost {
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
-                 const baldr::GraphId& graphid) const;
+                 const baldr::GraphId& edgeid) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -290,7 +290,7 @@ bool TruckCost::AllowMultiPass() const {
 bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& graphid) const {
+                       const baldr::GraphId& edgeid) const {
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(edge->forwardaccess() & kTruckAccess) ||
@@ -302,7 +302,7 @@ bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
 
   if (edge->access_restriction()) {
     const std::vector<baldr::AccessRestriction>& restrictions =
-        tile->GetAccessRestrictions(graphid.id(), kTruckAccess);
+        tile->GetAccessRestrictions(edgeid.id(), kTruckAccess);
 
     for (const auto& restriction : restrictions ) {
       // TODO:  Need to handle restictions that take place only at certain
@@ -348,7 +348,7 @@ bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const baldr::DirectedEdge* opp_edge,
                const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& graphid) const {
+               const baldr::GraphId& edgeid) const {
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(opp_edge->forwardaccess() & kTruckAccess) ||
@@ -359,7 +359,7 @@ bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
   }
 
   const std::vector<baldr::AccessRestriction>& restrictions =
-      tile->GetAccessRestrictions(graphid, kTruckAccess);
+      tile->GetAccessRestrictions(edgeid, kTruckAccess);
 
   for (const auto& restriction : restrictions ) {
     // TODO:  Need to handle restictions that take place only at certain

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -5,6 +5,8 @@
 #include <valhalla/baldr/nodeinfo.h>
 #include <valhalla/baldr/transitdeparture.h>
 #include <valhalla/baldr/transittransfer.h>
+#include <valhalla/baldr/accessrestriction.h>
+
 #include <memory>
 
 #include <valhalla/sif/hierarchylimits.h>
@@ -77,10 +79,12 @@ class DynamicCost {
    * based on other parameters.
    * @param  edge  Pointer to a directed edge.
    * @param  pred  Predecessor edge information.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
-                       const EdgeLabel& pred) const = 0;
+                       const EdgeLabel& pred,
+                       const std::vector<baldr::AccessRestriction>& restrictions) const = 0;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -91,12 +95,14 @@ class DynamicCost {
    * @param  opp_edge  Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
+   * @param  restrictions  Restrictions at this directed edge.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge) const = 0;
+                 const baldr::DirectedEdge* opp_pred_edge,
+                 const std::vector<baldr::AccessRestriction>& restrictions) const = 0;
 
   /**
    * Checks if access is allowed for the provided node. Node access can

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -5,7 +5,8 @@
 #include <valhalla/baldr/nodeinfo.h>
 #include <valhalla/baldr/transitdeparture.h>
 #include <valhalla/baldr/transittransfer.h>
-#include <valhalla/baldr/accessrestriction.h>
+#include <valhalla/baldr/graphid.h>
+#include <valhalla/baldr/graphtile.h>
 
 #include <memory>
 
@@ -77,32 +78,36 @@ class DynamicCost {
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
    * based on other parameters.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  edge     Pointer to a directed edge.
+   * @param  pred     Predecessor edge information.
+   * @param  tile     current tile
+   * @param  graphid  graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
-                       const std::vector<baldr::AccessRestriction>& restrictions) const = 0;
+                       const baldr::GraphTile*& tile,
+                       const baldr::GraphId& graphid) const = 0;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
    * (from destination towards origin). Both opposing edges are
    * provided.
-   * @param  edge  Pointer to a directed edge.
-   * @param  pred  Predecessor edge information.
-   * @param  opp_edge  Pointer to the opposing directed edge.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  opp_edge       Pointer to the opposing directed edge.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
-   * @param  restrictions  Restrictions at this directed edge.
+   * @param  tile           current tile
+   * @param  graphid        graphid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
-                 const std::vector<baldr::AccessRestriction>& restrictions) const = 0;
+                 const baldr::GraphTile*& tile,
+                 const baldr::GraphId& graphid) const = 0;
 
   /**
    * Checks if access is allowed for the provided node. Node access can

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -81,13 +81,13 @@ class DynamicCost {
    * @param  edge     Pointer to a directed edge.
    * @param  pred     Predecessor edge information.
    * @param  tile     current tile
-   * @param  graphid  graphid that we care about
+   * @param  edgeid   edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& graphid) const = 0;
+                       const baldr::GraphId& edgeid) const = 0;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -99,7 +99,7 @@ class DynamicCost {
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor.
    * @param  tile           current tile
-   * @param  graphid        graphid that we care about
+   * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
@@ -107,7 +107,7 @@ class DynamicCost {
                  const baldr::DirectedEdge* opp_edge,
                  const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
-                 const baldr::GraphId& graphid) const = 0;
+                 const baldr::GraphId& edgeid) const = 0;
 
   /**
    * Checks if access is allowed for the provided node. Node access can

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -174,6 +174,12 @@ class DynamicCost {
   virtual Cost TransferCost(const baldr::TransitTransfer* transfer) const;
 
   /**
+   * Returns the default transfer cost between 2 transit lines.
+   * @return  Returns the transfer cost and time (seconds).
+   */
+  virtual Cost DefaultTransferCost() const;
+
+  /**
    * Get the cost factor for A* heuristics. This factor is multiplied
    * with the distance to the destination to produce an estimate of the
    * minimum cost to the destination. The A* heuristic must underestimate the


### PR DESCRIPTION
Added init truck costing.  Contains the defaults and logic to try to avoid lower class roads.  Also, we process Hazmat, MaxAxleLoad, MaxHeight, MaxLength, MaxWeight, and MaxWidth restrictions for truck costing.  More tweaking via low_class_penalty may need to be done after more testing.  Seems pretty good right now.

Added use_rail, use_bus, and use_transfers to transit costing.  Also added a DefaultTransferCost for transferring between lines.  More tweaking must be done on Transit.

Allowed function defs have changed as well.