### PR TITLE
Add turn cost

### DIFF
--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -41,7 +41,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       predecessor_(predecessor) ,
       tripid_(0),
       prior_stopid_(0),
-      blockid_(0) {
+      blockid_(0),
+      turn_cost_(0) {
 }
 
 // Constructor with values - used in bidirectional A*
@@ -73,7 +74,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       predecessor_(predecessor) ,
       tripid_(0),
       prior_stopid_(0),
-      blockid_(0) {
+      blockid_(0),
+      turn_cost_(0)  {
 }
 
 // Constructor with values.  Used for multi-modal path.
@@ -106,7 +108,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
       predecessor_(predecessor) ,
       tripid_(tripid),
       prior_stopid_(prior_stopid),
-      blockid_(blockid) {
+      blockid_(blockid),
+      turn_cost_(0)  {
 }
 
 // Update predecessor and cost values in the label.
@@ -258,6 +261,16 @@ uint32_t EdgeLabel::prior_stopid() const {
 // Return the transit block Id of the prior trip.
 uint32_t EdgeLabel::blockid() const {
   return blockid_;
+}
+
+// Get the turn cost.
+uint32_t EdgeLabel::turn_cost() const {
+  return turn_cost_;
+}
+
+// Set the turn cost.
+void EdgeLabel::set_turn_cost(uint32_t tc) {
+  turn_cost_ = tc;
 }
 
 // Operator for sorting.

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -285,6 +285,21 @@ class EdgeLabel {
    */
   bool operator < (const EdgeLabel& other) const;
 
+  /**
+   * Get the turn cost. This is used in the bidirectional A* reverse
+   * path search to allow the recovery of the true elapsed time along the
+   * path. This is needed since the turn cost is applied at a different node
+   * than the forward search.
+   * @return  Returns the true turn cost (without penalties) in seconds.
+   */
+  uint32_t turn_cost() const;
+
+  /**
+   * Set the turn cost.
+   * @param  tc  True turn cost in seconds.
+   */
+  void set_turn_cost(uint32_t tc);
+
  private:
   // Graph Id of the edge.
   baldr::GraphId edgeid_;
@@ -349,6 +364,9 @@ class EdgeLabel {
 
   // Block Id
   uint32_t blockid_;
+
+  // Turn cost (used in bidirectional reverse path search).
+  uint32_t turn_cost_;
 };
 
 }


### PR DESCRIPTION
Needed to add turn cost (separate from Cost) to allow use in the reverse path. When forming the path and computing elapsed time for the reverse path the elapsed time is formed by differences between the Cost elapsed times. However, this applies the turn cost at the wrong edge so this PR allows it to be added to the EdgeLabel separately. A future thor PR will alter the reverse path search and FormPath methods to use this.