### PR TITLE
Allow mountain bikes on kPath edges in the search filter

### DIFF
--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -345,7 +345,7 @@ class BicycleCost : public DynamicCost {
         else if (b == BicycleType::kCross)
           return edge->surface() > Surface::kGravel;
         else if (b == BicycleType::kMountain)
-          return edge->surface() >= Surface::kPath;
+          return edge->surface() > Surface::kPath;
       }
       return true;
     };


### PR DESCRIPTION
They are allowed in the Allowed methods so this just makes it consistent.