### PR TITLE
Change turn cost to transition cost

### DIFF
--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -42,7 +42,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       tripid_(0),
       prior_stopid_(0),
       blockid_(0),
-      turn_cost_(0) {
+      transition_cost_(0) {
 }
 
 // Constructor with values - used in bidirectional A*
@@ -51,7 +51,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
                      const Cost& cost, const float sortcost, const float dist,
                      const uint32_t restrictions,
                      const uint32_t opp_local_idx,
-                     const TravelMode mode)
+                     const TravelMode mode, const uint32_t tc)
     : edgeid_(edgeid),
       opp_edgeid_(oppedgeid),
       endnode_(edge->endnode()),
@@ -75,7 +75,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       tripid_(0),
       prior_stopid_(0),
       blockid_(0),
-      turn_cost_(0)  {
+      transition_cost_(tc)  {
 }
 
 // Constructor with values.  Used for multi-modal path.
@@ -109,7 +109,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
       tripid_(tripid),
       prior_stopid_(prior_stopid),
       blockid_(blockid),
-      turn_cost_(0)  {
+      transition_cost_(0)  {
 }
 
 // Update predecessor and cost values in the label.
@@ -264,13 +264,13 @@ uint32_t EdgeLabel::blockid() const {
 }
 
 // Get the turn cost.
-uint32_t EdgeLabel::turn_cost() const {
-  return turn_cost_;
+uint32_t EdgeLabel::transition_cost() const {
+  return transition_cost_;
 }
 
 // Set the turn cost.
-void EdgeLabel::set_turn_cost(uint32_t tc) {
-  turn_cost_ = tc;
+void EdgeLabel::set_transition_cost(uint32_t tc) {
+  transition_cost_ = tc;
 }
 
 // Operator for sorting.

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -59,13 +59,15 @@ class EdgeLabel {
    *                  if edge is a transition edge. This allows restrictions
    *                  to be carried across different hierarchy levels.
    * @param mode      Mode of travel along this edge.
+   * @param tc        Real transition cost (separated from Cost for the
+   *                  reverse path logic.
    */
   EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
             const baldr::GraphId& oppedgeid,
             const baldr::DirectedEdge* edge, const Cost& cost,
             const float sortcost, const float dist,
             const uint32_t restrictions, const uint32_t opp_local_idx,
-            const TravelMode mode);
+            const TravelMode mode, const uint32_t tc);
 
   /**
    * Constructor with values.  Used for multi-modal path.
@@ -286,19 +288,19 @@ class EdgeLabel {
   bool operator < (const EdgeLabel& other) const;
 
   /**
-   * Get the turn cost. This is used in the bidirectional A* reverse
-   * path search to allow the recovery of the true elapsed time along the
-   * path. This is needed since the turn cost is applied at a different node
-   * than the forward search.
-   * @return  Returns the true turn cost (without penalties) in seconds.
+   * Get the transition cost in seconds. This is used in the bidirectional A*
+   * reverse path search to allow the recovery of the true elapsed time along
+   * the path. This is needed since the turn cost is applied at a different
+   * node than the forward search.
+   * @return  Returns the true transition cost (without penalties) in seconds.
    */
-  uint32_t turn_cost() const;
+  uint32_t transition_cost() const;
 
   /**
-   * Set the turn cost.
-   * @param  tc  True turn cost in seconds.
+   * Set the transition cost.
+   * @param  tc  True transition cost in seconds.
    */
-  void set_turn_cost(uint32_t tc);
+  void set_transition_cost(uint32_t tc);
 
  private:
   // Graph Id of the edge.
@@ -365,8 +367,9 @@ class EdgeLabel {
   // Block Id
   uint32_t blockid_;
 
-  // Turn cost (used in bidirectional reverse path search).
-  uint32_t turn_cost_;
+  // Real transition cost in seconds (used in bidirectional reverse
+  // path search).
+  uint32_t transition_cost_;
 };
 
 }

--- a/valhalla/sif/hierarchylimits.h
+++ b/valhalla/sif/hierarchylimits.h
@@ -88,10 +88,22 @@ struct HierarchyLimits {
    * within the specified distance from the destination regardless of
    * count.
    * @param  dist  Distance (meters) from the destination.
+   * @return  Returns true if expansion at this hierarchy level should stop.
    */
   bool StopExpanding(const float dist) const {
     return (dist > expansion_within_dist &&
             up_transition_count > max_up_transitions);
+  }
+
+  /**
+   * Determine if expansion of a hierarchy level should be stopped once
+   * the number of upward transitions has been exceeded. This is used in
+   * the bidirectional method where distance from the destination does not
+   * matter.
+   * @return  Returns true if expansion at this hierarchy level should stop.
+   */
+  bool StopExpanding() const {
+    return up_transition_count > max_up_transitions;
   }
 
   /**


### PR DESCRIPTION
Add to constructor for EdgeLabel (used in bidirectional A*).
Add a separate StopExpanding method to hierarchylimits - used in bidrectional A* where distance from destination is not a factor.