### PR TITLE
lower mode weights

### DIFF
--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -25,7 +25,7 @@ constexpr uint32_t kMaxTransferDistanceMM    = 805;   // 0.5 miles
 // Maximum distance of a walking route
 constexpr uint32_t kMaxDistance        = 100000; // 100 km
 
-constexpr float kModeWeight             = 2.5f;   // Favor this mode?
+constexpr float kModeWeight             = 2.0f;   // Favor this mode?
 constexpr float kDefaultManeuverPenalty = 5.0f;   // Seconds
 constexpr float kDefaultGatePenalty     = 300.0f; // Seconds
 constexpr float kDefaultWalkingSpeed    = 5.1f;   // 3.16 MPH

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -13,7 +13,7 @@ namespace sif {
 namespace {
 constexpr uint32_t kUnitSize = 1;
 
-constexpr float kModeWeight             = 1.5f; // Favor this mode?
+constexpr float kModeWeight             = 1.0f; // Favor this mode?
 constexpr float kDefaultTransferCost    = 15.0f;
 constexpr float kDefaultTransferPenalty = 300.0f;
 

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -13,7 +13,7 @@ namespace sif {
 namespace {
 constexpr uint32_t kUnitSize = 1;
 
-constexpr float kModeWeight             = 2.0f; // Favor this mode?
+constexpr float kModeWeight             = 1.5f; // Favor this mode?
 constexpr float kDefaultTransferCost    = 15.0f;
 constexpr float kDefaultTransferPenalty = 300.0f;
 

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -338,27 +338,6 @@ Cost TransitCost::TransitionCost(const baldr::DirectedEdge* edge,
   return { 0.0f, 0.0f };
 }
 
-/*
-// Returns the transfer cost between 2 transit stops.
-Cost TransitCost::TransferCost(const TransitTransfer* transfer) const {
-  if (transfer == nullptr) {
-    // No transfer record exists - use defaults
-    return { transfer_cost_ + (transfer_penalty_ * transfer_factor_), transfer_cost_ };
-  }
-  switch (transfer->type()) {
-  case TransferType::kRecommended:
-    return { transfer_cost_ + (transfer_penalty_ * transfer_factor_), transfer_cost_ };
-  case TransferType::kTimed:
-    return { transfer_cost_ + (transfer_penalty_ * transfer_factor_), transfer_cost_ };
-  case TransferType::kMinTime:
-    return { static_cast<float>(transfer->mintime() + (transfer_penalty_ * transfer_factor_)),
-             static_cast<float>(transfer->mintime()) };
-  case TransferType::kNotPossible:
-    return kImpossibleCost;
-  }
-}
-*/
-
 // Returns the transfer cost between 2 transit stops.
 Cost TransitCost::TransferCost(const TransitTransfer* transfer) const {
   if (transfer == nullptr) {


### PR DESCRIPTION
This with thor updates fixes switching operators, taking buses when not needed, and take a more desired bus route.

<code><pre>
Avoid path example://

<    Depart: 8:05 AM from 23rd Street.
<    VERBAL_DEPART: Depart at 8:05 AM from 23rd Street.
< 4: Take the PATH toward Journal Square. (1 stop) | 0.4 mi
<    VERBAL_PRE: Take the PATH toward Journal Square.
<    VERBAL_POST: Travel 1 stop.
<    Arrive: 8:06 AM at 14th Street.
<    VERBAL_ARRIVE: Arrive at 8:06 AM at 14th Street.
< 5: Transfer at the 6 Av station. | 0.0 mi
<    VERBAL_PRE: Transfer at the 6 Av station.
<    VERBAL_POST: Continue for 20 feet.
<    Depart: 8:06 AM from 6 Av.
<    VERBAL_DEPART: Depart at 8:06 AM from 6 Av.
< 6: Take the L toward CANARSIE - ROCKAWAY PKWY. (9 stops) | 4.2 mi
<    VERBAL_PRE: Take the L toward CANARSIE - ROCKAWAY PKWY.
<    VERBAL_POST: Travel 9 stops.
<    Arrive: 8:20 AM at Morgan Av.
<    VERBAL_ARRIVE: Arrive at 8:20 AM at Morgan Av.
> 9: Enter the Union Sq - 14 St station. | 0.0 mi
>    VERBAL_PRE: Enter the Union Sq - 14 St station.
>    VERBAL_POST: Continue for 30 feet.
>    Depart: 8:11 AM from Union Sq - 14 St.
>    VERBAL_DEPART: Depart at 8:11 AM from Union Sq - 14 St.
> 10: Take the L toward MYRTLE - WYCKOFF AVS. (8 stops) | 3.8 mi
>    VERBAL_PRE: Take the L toward MYRTLE - WYCKOFF AVS.
>    VERBAL_POST: Travel 8 stops.
>    Arrive: 8:23 AM at Morgan Av.

No need to take a bus example://

< 5: Head north on Church Street. | 0.0 mi
<    VERBAL_PRE: Head north on Church Street.
<    VERBAL_POST: Continue for 40 feet.
> 5: Head south on Church Street. | 0.3 mi
>    VERBAL_PRE: Head south on Church Street.
>    VERBAL_POST: Continue for 3 tenths of a mile.
27,33c27,29
<    Depart: 5:44 PM from Church St & Duboce Ave.
<    VERBAL_DEPART: Depart at 5:44 PM from Church St & Duboce Ave.
< 6: Take the 22 toward Potrero Hill. (2 stops) | 0.3 mi
<    VERBAL_PRE: Take the 22 toward Potrero Hill.
<    VERBAL_POST: Travel 2 stops.
<    Arrive: 5:48 PM at Church St & 16th St.
<    VERBAL_ARRIVE: Arrive at 5:48 PM at Church St & 16th St.
> 6: Enter the Church St & 16th St station. | 0.0 mi
>    VERBAL_PRE: Enter the Church St & 16th St station.
>    VERBAL_POST: Continue for 20 feet.
37,38c33,34
< 7: Transfer to take the J toward Balboa Park Station. (9 stops) | 1.5 mi
<    VERBAL_PRE: Transfer to take the J toward Balboa Park Station.
> 7: Take the J toward Balboa Park Station. (9 stops) | 1.5 mi
>    VERBAL_PRE: Take the J toward Balboa Park Station.

Better bus result.  22 to 522 is better.

<    Depart: 8:23 AM from EL CAMINO & CALDERON.
<    VERBAL_DEPART: Depart at 8:23 AM from EL CAMINO & CALDERON.
< 5: Take the 22. (2 stops) | 0.5 mi
<    VERBAL_PRE: Take the 22.
<    VERBAL_POST: Travel 2 stops.
<    Arrive: 8:27 AM at EL CAMINO & CASTRO.
<    VERBAL_ARRIVE: Arrive at 8:27 AM at EL CAMINO & CASTRO.
>    Depart: 8:27 AM from MOUNTAIN VIEW CALTRAIN STATION.
>    VERBAL_DEPART: Depart at 8:27 AM from MOUNTAIN VIEW CALTRAIN STATION.
> 7: Take the 52. (4 stops) | 0.7 mi
>    VERBAL_PRE: Take the 52.
>    VERBAL_POST: Travel 4 stops.
>    Arrive: 8:33 AM at EL CAMINO & CASTRO.
>    VERBAL_ARRIVE: Arrive at 8:33 AM at EL CAMINO & CASTRO.
32c42
< 6: Transfer to take the 522. (4 stops) | 6.0 mi
> 8: Transfer to take the 522. (4 stops) | 6.0 mi

</code></pre>
