### PR TITLE
Penalize transit connection transitions at a transit node

### DIFF
--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -42,6 +42,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       tripid_(0),
       prior_stopid_(0),
       blockid_(0),
+      transit_operator_(0),
       transition_cost_(0) {
 }
 
@@ -75,6 +76,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       tripid_(0),
       prior_stopid_(0),
       blockid_(0),
+      transit_operator_(0),
       transition_cost_(tc)  {
 }
 
@@ -85,7 +87,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
           const uint32_t restrictions, const uint32_t opp_local_idx,
           const TravelMode mode, const uint32_t walking_distance,
           const uint32_t tripid, const uint32_t prior_stopid,
-          const uint32_t blockid, const bool has_transit)
+          const uint32_t blockid, const uint32_t transit_operator,
+          const bool has_transit)
     : edgeid_(edgeid),
       opp_edgeid_ {},
       endnode_(edge->endnode()),
@@ -109,6 +112,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
       tripid_(tripid),
       prior_stopid_(prior_stopid),
       blockid_(blockid),
+      transit_operator_(transit_operator),
       transition_cost_(0)  {
 }
 
@@ -261,6 +265,11 @@ uint32_t EdgeLabel::prior_stopid() const {
 // Return the transit block Id of the prior trip.
 uint32_t EdgeLabel::blockid() const {
   return blockid_;
+}
+
+// Get the index of the transit operator.
+uint32_t EdgeLabel::transit_operator() const {
+  return transit_operator_;
 }
 
 // Get the turn cost.

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -365,11 +365,13 @@ Cost PedestrianCost::TransitionCost(const baldr::DirectedEdge* edge,
     return { step_penalty_, 0.0f };
   }
 
-  // Nominal cost from transit connection
-  // TODO - validate if this is needed to prevent going into transit
-  // stops (without boarding a transit line) as a shortcut
-  if (pred.use() == Use::kTransitConnection) {
-    return { 30.0f, 0.0f };
+  // Prevent going from one transit connection directly to another
+  // at a transit stop - this is like entering a station and exiting
+  // without getting on transit
+  if (node->type() == NodeType::kMultiUseTransitStop &&
+      pred.use()   == Use::kTransitConnection &&
+      edge->use()  == Use::kTransitConnection) {
+    return { 300.0f, 0.0f };
   }
 
   // Penalty through gates and border control.

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -86,6 +86,7 @@ class EdgeLabel {
    * @param tripid    Trip Id for a transit edge.
    * @param prior_stopid  Prior transit stop Id.
    * @param blockid   Transit trip block Id.
+   * @param transit_operator Transit operator - index into an internal map
    * @param has_transit Does the path to this edge have any transit.
    */
   EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
@@ -94,7 +95,8 @@ class EdgeLabel {
             const uint32_t restrictions, const uint32_t opp_local_idx,
             const TravelMode mode, const uint32_t walking_distance,
             const uint32_t tripid, const uint32_t prior_stopid,
-            const uint32_t blockid, const bool has_transit);
+            const uint32_t blockid, const uint32_t transit_operator,
+            const bool has_transit);
 
   /**
    * Update an existing edge label with new predecessor and cost information.
@@ -283,6 +285,12 @@ class EdgeLabel {
   uint32_t blockid() const;
 
   /**
+   * Get the index of the transit operator.
+   * @return  Returns the transit operator index (0 if none).
+   */
+  uint32_t transit_operator() const;
+
+  /**
    * Operator < used for sorting.
    */
   bool operator < (const EdgeLabel& other) const;
@@ -366,6 +374,9 @@ class EdgeLabel {
 
   // Block Id
   uint32_t blockid_;
+
+  // Prior operator (index in an internal mapping). 0 indicates no prior
+  uint32_t transit_operator_;
 
   // Real transition cost in seconds (used in bidirectional reverse
   // path search).


### PR DESCRIPTION
High penalty to go directly from a transit connection to another at a transit node. This is to prevent entering a stop then exiting without taking transit.