### PR TITLE
Transit costing and transfer changes

### DIFF
--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -25,7 +25,7 @@ constexpr uint32_t kMaxTransferDistanceMM    = 805;   // 0.5 miles
 // Maximum distance of a walking route
 constexpr uint32_t kMaxDistance        = 100000; // 100 km
 
-constexpr float kModeWeight             = 2.0f;   // Favor this mode?
+constexpr float kModeWeight             = 1.5f;   // Favor this mode?
 constexpr float kDefaultManeuverPenalty = 5.0f;   // Seconds
 constexpr float kDefaultGatePenalty     = 300.0f; // Seconds
 constexpr float kDefaultWalkingSpeed    = 5.1f;   // 3.16 MPH

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -342,7 +342,7 @@ Cost TransitCost::TransitionCost(const baldr::DirectedEdge* edge,
 Cost TransitCost::TransferCost(const TransitTransfer* transfer) const {
   if (transfer == nullptr) {
     // No transfer record exists - use defaults
-    return { transfer_cost_ +  (transfer_penalty_ * transfer_factor_), transfer_cost_};
+    return { (transfer_cost_ +  transfer_penalty_) * transfer_factor_, transfer_cost_ };
   }
   switch (transfer->type()) {
     case TransferType::kRecommended:


### PR DESCRIPTION
Influence the total transfer cost (time + penalty) by the transfer factor. 	Separate wait time from elapsed time and only apply penalty to transit elapsed time. Normalize factors to 1.0 as the lowest. Increase the penalty for stop to stop transfers. Set defaults if inputs are outside of range.
Reduce pedestrian mode weight within multimodal routes.