### PR TITLE
Fix AllowedReverse use of turn restrictions.

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -101,8 +101,6 @@ class AutoCost : public DynamicCost {
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
-   *                        predecessor.
    * @param  tile           current tile
    * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
@@ -110,7 +108,6 @@ class AutoCost : public DynamicCost {
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
                  const baldr::GraphId& edgeid) const;
 
@@ -297,7 +294,6 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
 bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
                const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
@@ -305,8 +301,8 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(opp_edge->forwardaccess() & kAutoAccess) ||
-       (pred.opp_local_idx() == edge->localedgeidx()) ||
-       (opp_edge->restrictions() & (1 << opp_pred_edge->localedgeidx())) ||
+        pred.opp_local_idx() == edge->localedgeidx() ||
+       (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
         opp_edge->surface() == Surface::kImpassable) {
     return false;
   }
@@ -564,16 +560,15 @@ class BusCost : public AutoCost {
    * (from destination towards origin). Both opposing edges are
    * provided.
    * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
-   *                        predecessor.
    * @param  tile           current tile
    * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
+                 const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
                  const baldr::GraphId& edgeid) const;
 
@@ -626,18 +621,18 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
 // Checks if access is allowed for an edge on the reverse path (from
 // destination towards origin). Both opposing edges are provided.
 bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
-               const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge,
-               const baldr::GraphTile*& tile,
-               const baldr::GraphId& edgeid) const {
+                             const EdgeLabel& pred,
+                             const baldr::DirectedEdge* opp_edge,
+                             const baldr::GraphTile*& tile,
+                             const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(opp_edge->forwardaccess() & kBusAccess) ||
-      (opp_pred_edge->opp_local_idx() == opp_edge->opp_local_idx()) ||
-      (opp_edge->restrictions() & (1 << opp_pred_edge->localedgeidx())) ||
-       opp_edge->surface() == Surface::kImpassable) {
+        pred.opp_local_idx() == edge->localedgeidx() ||
+       (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
+        opp_edge->surface() == Surface::kImpassable) {
     return false;
   }
   return true;

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -189,8 +189,6 @@ class BicycleCost : public DynamicCost {
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
-   *                        predecessor.
    * @param  tile           current tile
    * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
@@ -198,7 +196,6 @@ class BicycleCost : public DynamicCost {
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
                  const baldr::GraphId& edgeid) const;
 
@@ -505,7 +502,6 @@ bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
 bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
                const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
@@ -515,7 +511,7 @@ bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
   // since the search is heading out of any not_thru regions)
   if (!(opp_edge->forwardaccess() & kBicycleAccess) ||
        (pred.opp_local_idx() == edge->localedgeidx()) ||
-       (opp_edge->restrictions() & (1 << opp_pred_edge->localedgeidx()))) {
+       (opp_edge->restrictions() & (1 << pred.opp_local_idx()))) {
     return false;
   }
 

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -100,8 +100,6 @@ class PedestrianCost : public DynamicCost {
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
-   *                        predecessor.
    * @param  tile           current tile
    * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
@@ -109,7 +107,6 @@ class PedestrianCost : public DynamicCost {
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
                  const baldr::GraphId& edgeid) const;
 
@@ -317,7 +314,6 @@ bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
 bool PedestrianCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
                const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -76,8 +76,6 @@ class TransitCost : public DynamicCost {
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
-   *                        predecessor.
    * @param  tile           current tile
    * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
@@ -85,7 +83,6 @@ class TransitCost : public DynamicCost {
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
                  const baldr::GraphId& edgeid) const;
 
@@ -288,7 +285,6 @@ bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
 bool TransitCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
                const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -117,8 +117,6 @@ class TruckCost : public DynamicCost {
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
-   *                        predecessor.
    * @param  tile           current tile
    * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
@@ -126,7 +124,6 @@ class TruckCost : public DynamicCost {
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
                  const baldr::GraphId& edgeid) const;
 
@@ -346,14 +343,13 @@ bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
 bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
-               const baldr::DirectedEdge* opp_pred_edge,
                const baldr::GraphTile*& tile,
                const baldr::GraphId& edgeid) const {
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(opp_edge->forwardaccess() & kTruckAccess) ||
        (pred.opp_local_idx() == edge->localedgeidx()) ||
-       (opp_edge->restrictions() & (1 << opp_pred_edge->localedgeidx())) ||
+       (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
        opp_edge->surface() == Surface::kImpassable) {
     return false;
   }

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -110,8 +110,6 @@ class DynamicCost {
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
-   *                        predecessor.
    * @param  tile           current tile
    * @param  edgeid         edgeid that we care about
    * @return  Returns true if access is allowed, false if not.
@@ -119,7 +117,6 @@ class DynamicCost {
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
                  const EdgeLabel& pred,
                  const baldr::DirectedEdge* opp_edge,
-                 const baldr::DirectedEdge* opp_pred_edge,
                  const baldr::GraphTile*& tile,
                  const baldr::GraphId& edgeid) const = 0;
 


### PR DESCRIPTION
Did not need the opposing predecessor edge - just use the predecessor opposing local index. This
is safer anyway since this is handled when transitions between hierarchies are included.