### PR TITLE
moved logic to multimodal.cc

### DIFF
--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -16,7 +16,7 @@ wait
 for dep in midgard baldr; do
 	pushd deps/$dep
 	./autogen.sh
-	./configure CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE
+	./configure CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS"
 	make -j$(nproc)
 	sudo make install
 	popd

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,6 @@ set -e
 
 export LD_LIBRARY_PATH=.:`cat /etc/ld.so.conf.d/* | grep -v -E "#" | tr "\\n" ":" | sed -e "s/:$//g"`
 ./autogen.sh
-./configure --enable-coverage CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE
+./configure --enable-coverage CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS"
 make test -j$(nproc)
 sudo make install

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -370,15 +370,6 @@ Cost PedestrianCost::TransitionCost(const baldr::DirectedEdge* edge,
     return { step_penalty_, 0.0f };
   }
 
-  // Prevent going from one transit connection directly to another
-  // at a transit stop - this is like entering a station and exiting
-  // without getting on transit
-  if (node->type() == NodeType::kMultiUseTransitStop &&
-      pred.use()   == Use::kTransitConnection &&
-      edge->use()  == Use::kTransitConnection) {
-    return { 300.0f, 0.0f };
-  }
-
   // Penalty through gates and border control.
   float seconds = 0.0f;
   float penalty = 0.0f;


### PR DESCRIPTION
Moved prevent going from one transit connection directly to another at a transit stop logic from sif to multimodal in thor.  We always want to avoid these in pedestrian mode.