### PR TITLE
Need both cost and time for transition costs to form proper connection for bidirectional A*.

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -270,8 +270,7 @@ bool AutoCost::AllowMultiPass() const {
   return true;
 }
 
-// Check if access is allowed on the specified edge. Not worth checking
-// not_thru due to hierarchy transitions
+// Check if access is allowed on the specified edge.
 bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
@@ -599,8 +598,7 @@ BusCost::BusCost(const boost::property_tree::ptree& pt)
 BusCost::~BusCost() {
 }
 
-// Check if access is allowed on the specified edge. Not worth checking
-// not_thru due to hierarchy transitions
+// Check if access is allowed on the specified edge.
 bool BusCost::Allowed(const baldr::DirectedEdge* edge,
                       const EdgeLabel& pred,
                       const baldr::GraphTile*& tile,

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -505,8 +505,6 @@ bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
-  // Check if edge is not-thru (no need to check distance from destination
-  // since the search is heading out of any not_thru regions)
   if (!(opp_edge->forwardaccess() & kBicycleAccess) ||
        (pred.opp_local_idx() == edge->localedgeidx()) ||
        (opp_edge->restrictions() & (1 << pred.opp_local_idx()))) {

--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -354,6 +354,10 @@ bool EdgeLabel::not_thru() const {
   return not_thru_;
 }
 
+// Set the not-through flag for this edge.
+void EdgeLabel::set_not_thru(const bool not_thru) {
+  not_thru_ = not_thru;
+}
 
 // Operator for sorting.
 bool EdgeLabel::operator < (const EdgeLabel& other) const {

--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -43,7 +43,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       prior_stopid_(0),
       blockid_(0),
       transit_operator_(0),
-      transition_cost_(0) {
+      transition_cost_(0),
+      transition_secs_(0) {
 }
 
 // Constructor with values - used in bidirectional A*
@@ -52,7 +53,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
                      const Cost& cost, const float sortcost, const float dist,
                      const uint32_t restrictions,
                      const uint32_t opp_local_idx,
-                     const TravelMode mode, const uint32_t tc)
+                     const TravelMode mode, const Cost& tc)
     : edgeid_(edgeid),
       opp_edgeid_(oppedgeid),
       endnode_(edge->endnode()),
@@ -77,7 +78,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       prior_stopid_(0),
       blockid_(0),
       transit_operator_(0),
-      transition_cost_(tc)  {
+      transition_cost_(tc.cost),
+      transition_secs_(tc.secs) {
 }
 
 // Constructor with values.  Used for multi-modal path.
@@ -113,7 +115,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
       prior_stopid_(prior_stopid),
       blockid_(blockid),
       transit_operator_(transit_operator),
-      transition_cost_(0)  {
+      transition_cost_(0),
+      transition_secs_(0) {
 }
 
 // Update predecessor and cost values in the label.
@@ -272,14 +275,24 @@ uint32_t EdgeLabel::transit_operator() const {
   return transit_operator_;
 }
 
-// Get the turn cost.
+// Get the transition cost in seconds. This is used in the bidirectional A*
+// to determine the cost at the connection.
 uint32_t EdgeLabel::transition_cost() const {
   return transition_cost_;
 }
 
-// Set the turn cost.
-void EdgeLabel::set_transition_cost(uint32_t tc) {
-  transition_cost_ = tc;
+// Get the transition cost in seconds. This is used in the bidirectional A*
+// reverse path search to allow the recovery of the true elapsed time along
+// the path. This is needed since the transition cost is applied at a different
+// node than the forward search.
+uint32_t EdgeLabel::transition_secs() const {
+  return transition_secs_;
+}
+
+// Set the transition cost.
+void EdgeLabel::set_transition_cost(const Cost& tc) {
+  transition_cost_ = tc.cost;
+  transition_secs_ = tc.secs;
 }
 
 // Operator for sorting.

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -316,11 +316,10 @@ bool PedestrianCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
-  // Disallow if no pedestrian access, surface marked as impassible, Uturn,
-  // or edge is not-thru (no need to check distance from destination since
-  // the search is heading out of any not_thru regions). Do not check max
-  // walking distance and assume we are not allowing transit connections.
-  // Assume this method is never used in multimodal routes).
+  // Disallow if no pedestrian access, surface marked as impassible, or
+  // is a Uturn. Do not check max walking distance and assume we are not
+  // allowing transit connections. Assume this method is never used in
+  // multimodal routes).
   if (!(opp_edge->forwardaccess() & kPedestrianAccess) ||
        (pred.opp_local_idx() == edge->localedgeidx()) ||
         opp_edge->surface() == Surface::kImpassable ||

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -282,8 +282,7 @@ bool TruckCost::AllowMultiPass() const {
   return true;
 }
 
-// Check if access is allowed on the specified edge. Not worth checking
-// not_thru due to hierarchy transitions
+// Check if access is allowed on the specified edge.
 bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -358,6 +358,12 @@ class EdgeLabel {
    */
   bool not_thru() const;
 
+  /**
+   * Set the not-through flag for this edge.
+   * @param  not_thru  True if the edge is not thru.
+   */
+  void set_not_thru(const bool not_thru);
+
  private:
   // Graph Id of the edge.
   baldr::GraphId edgeid_;


### PR DESCRIPTION
Remove comments on not_thru edges. Add override method to set not_thru on predecessor.