### PR TITLE
Use higher of turn degree cost and crossing cost.

### DIFF
--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -12,7 +12,7 @@ namespace sif {
 
 // Default options/values
 namespace {
-constexpr float kDefaultManeuverPenalty         = 10.0f;  // Seconds
+constexpr float kDefaultManeuverPenalty         = 5.0f;   // Seconds
 constexpr float kDefaultDestinationOnlyPenalty  = 300.0f; // Seconds
 constexpr float kDefaultAlleyPenalty            = 30.0f;  // Seconds
 constexpr float kDefaultGateCost                = 30.0f;  // Seconds

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -425,11 +425,10 @@ class EdgeLabel {
   // Transit trip Id
   uint32_t tripid_;
 
-  // Block Id
-  uint32_t blockid_;
-
-  // Prior operator (index in an internal mapping). 0 indicates no prior
-  uint32_t transit_operator_;
+  // Block Id and prior operator (index to an internal mapping).
+  // 0 indicates no prior.
+  uint32_t blockid_          : 22;
+  uint32_t transit_operator_ : 10;
 
   // Transition cost (used in bidirectional path search).
   uint32_t transition_cost_ : 16;


### PR DESCRIPTION
Fixes issue #88 
Reduce default maneuver penalty for bicycles.
Also, combine transit operator and block Id into a single int. Reduces structure size to 64 bytes.