### PR TITLE
Allow U-turns at dead ends for auto routes.

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -298,9 +298,11 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
-  // TODO - perhaps allow U-turns at dead-end nodes?
+  // Allow U-turns at dead-end nodes in case the origin is inside
+  // a not thru region and a heading selected an edge entering the
+  // region.
   if (!(edge->forwardaccess() & kAutoAccess) ||
-      (pred.opp_local_idx() == edge->localedgeidx()) ||
+      (pred.opp_local_idx() == edge->localedgeidx() && !pred.deadend()) ||
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
        edge->surface() == Surface::kImpassable) {
     return false;
@@ -318,9 +320,9 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
-  // TODO - perhaps allow U-turns at dead-end nodes?
+  // Allow U-turns at dead-end nodes.
   if (!(opp_edge->forwardaccess() & kAutoAccess) ||
-        pred.opp_local_idx() == edge->localedgeidx() ||
+       (pred.opp_local_idx() == edge->localedgeidx() && !pred.deadend()) ||
        (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
         opp_edge->surface() == Surface::kImpassable) {
     return false;

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -652,9 +652,9 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
-  // TODO - perhaps allow U-turns at dead-end nodes?
+  // Allow U-turns at dead-end nodes.
   if (!(edge->forwardaccess() & kBusAccess) ||
-      (pred.opp_local_idx() == edge->localedgeidx()) ||
+      (pred.opp_local_idx() == edge->localedgeidx() && !pred.deadend()) ||
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
        edge->surface() == Surface::kImpassable) {
     return false;
@@ -672,9 +672,9 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
-  // TODO - perhaps allow U-turns at dead-end nodes?
+  // Allow U-turns at dead-end nodes.
   if (!(opp_edge->forwardaccess() & kBusAccess) ||
-        pred.opp_local_idx() == edge->localedgeidx() ||
+       (pred.opp_local_idx() == edge->localedgeidx() && !pred.deadend()) ||
        (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
         opp_edge->surface() == Surface::kImpassable) {
     return false;

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -20,7 +20,7 @@ enum class BicycleType {
   kMountain = 3
 };
 
-constexpr float kDefaultManeuverPenalty         = 5.0f;   // Seconds
+constexpr float kDefaultManeuverPenalty         = 20.0f;  // Seconds
 constexpr float kDefaultDestinationOnlyPenalty  = 300.0f; // Seconds
 constexpr float kDefaultAlleyPenalty            = 30.0f;  // Seconds
 constexpr float kDefaultGateCost                = 30.0f;  // Seconds
@@ -34,22 +34,23 @@ constexpr float kDefaultCountryCrossingPenalty  = 0.0f;   // Seconds
 constexpr float kMaxFerryPenalty = 8.0f * 3600.0f; // 8 hours
 
 // Default turn costs - modified by the stop impact.
-constexpr float kTCStraight         = 0.15f;
-constexpr float kTCSlight           = 0.2f;
-constexpr float kTCFavorable        = 0.3f;
-constexpr float kTCFavorableSharp   = 0.5f;
-constexpr float kTCCrossing         = 0.75f;
-constexpr float kTCUnfavorable      = 1.0f;
-constexpr float kTCUnfavorableSharp = 1.5f;
-constexpr float kTCReverse          = 5.0f;
+constexpr float kTCStraight          = 0.15f;
+constexpr float kTCFavorableSlight   = 0.2f;
+constexpr float kTCFavorable         = 0.3f;
+constexpr float kTCFavorableSharp    = 0.5f;
+constexpr float kTCCrossing          = 0.75f;
+constexpr float kTCUnfavorableSlight = 0.4f;
+constexpr float kTCUnfavorable       = 1.0f;
+constexpr float kTCUnfavorableSharp  = 1.5f;
+constexpr float kTCReverse           = 5.0f;
 
 // Turn costs based on side of street driving
-constexpr float kRightSideTurnCosts[] = { kTCStraight, kTCSlight,
+constexpr float kRightSideTurnCosts[] = { kTCStraight, kTCFavorableSlight,
       kTCFavorable, kTCFavorableSharp, kTCReverse, kTCUnfavorableSharp,
-      kTCUnfavorable, kTCSlight };
-constexpr float kLeftSideTurnCosts[]  = { kTCStraight, kTCSlight,
+      kTCUnfavorable, kTCUnfavorableSlight };
+constexpr float kLeftSideTurnCosts[]  = { kTCStraight, kTCUnfavorableSlight,
       kTCUnfavorable, kTCUnfavorableSharp, kTCReverse, kTCFavorableSharp,
-      kTCFavorable, kTCSlight };
+      kTCFavorable, kTCFavorableSlight };
 
 // Cost of traversing an edge with steps. Make this high but not impassible.
 // Equal to about 5 minutes (penalty) but fixed time of 30 seconds.
@@ -98,11 +99,11 @@ constexpr float kDrivewayFactor = 20.0f;
 // roads. These penalties are modulated by the useroads factor - further
 // avoiding higher class roads for those with low propensity for using roads.
 constexpr float kRoadClassFactor[] = {
-    0.75f,  // Motorway
-    0.5f,   // Trunk
-    0.35f,  // Primary
-    0.25f,  // Secondary
-    0.1f,   // Tertiary
+    1.0f,   // Motorway
+    0.4f,   // Trunk
+    0.2f,   // Primary
+    0.1f,   // Secondary
+    0.05f,  // Tertiary
     0.05f,  // Unclassified
     0.0f,   // Residential
     0.5f    // Service, other
@@ -140,22 +141,22 @@ constexpr float kDefaultUseHillsFactor = 0.5f;
 // edges with the specified grade are weighted. Note that speed also is
 // influenced by grade, so these weights help furhte ravoid hills.
 constexpr float kAvoidHillsStrength[] = {
-  2.0f,      // -10%  - Treacherous descent possible
-  1.0f,      // -8%   - Steep downhill
-  0.5f,      // -6.5% - Good downhill - where is the bottom?
-  0.3f,      // -5%   - Picking up speed!
-  0.2f,      // -3%   - Modest downhill
-  0.1f,      // -1.5% - Smooth slight downhill, ride this all day!
-  0.0f,      // 0%    - Flat, no avoidance
-  0.1f,      // 1.5%  - These are called "false flat"
-  0.2f,      // 3%    - Slight rise
-  0.3f,      // 5%    - Small hill
-  0.5f,      // 6.5%  - Starting to feel this...
-  1.0f,      // 8%    - Moderately steep
-  2.5f,      // 10%   - Getting tough
-  5.0f,      // 11.5% - Tiring!
-  7.5f,      // 13%   - Ooof - this hurts
-  10.0f      // 15%   - Only for the strongest!
+    1.0f,      // -10%  - Treacherous descent possible
+    0.5f,      // -8%   - Steep downhill
+    0.1f,      // -6.5% - Good downhill - where is the bottom?
+    0.05f,     // -5%   - Picking up speed!
+    0.025f,    // -3%   - Modest downhill
+    0.0f,      // -1.5% - Smooth slight downhill, ride this all day!
+    0.05f,     // 0%    - Flat, no avoidance
+    0.1f,      // 1.5%  - These are called "false flat"
+    0.15f,     // 3%    - Slight rise
+    0.3f,      // 5%    - Small hill
+    0.6f,      // 6.5%  - Starting to feel this...
+    1.2f,      // 8%    - Moderately steep
+    2.5f,      // 10%   - Getting tough
+    5.0f,      // 11.5% - Tiring!
+    7.5f,      // 13%   - Ooof - this hurts
+   10.0f       // 15%   - Only for the strongest!
 };
 
 // Edge speed above which extra penalties apply (to avoid roads with higher
@@ -164,7 +165,7 @@ constexpr float kAvoidHillsStrength[] = {
 constexpr uint32_t kSpeedPenaltyThreshold = 40;      // 40 KPH ~ 25 MPH
 
 // How much to favor bicycle networks.
-constexpr float kBicycleNetworkFactor = 0.85f;
+constexpr float kBicycleNetworkFactor = 1.0f;
 }
 
 /**
@@ -298,8 +299,13 @@ class BicycleCost : public DynamicCost {
   // Minimal surface type usable by the bicycle type
   Surface minimal_allowed_surface_;
 
-  // Surface speed factors
+  // Surface speed factors (based on road surface type).
   const float* surface_speed_factor_;
+
+  // Speed penalty factor. Penalties apply above a threshold
+  // (based on the use_roads factor)
+  float speedpenalty_[100];
+  uint32_t speed_penalty_threshold_;
 
   // A measure of willingness to ride with traffic. Ranges from 0-1 with
   // 0 being not willing at all and 1 being totally comfortable. This factor
@@ -315,11 +321,6 @@ class BicycleCost : public DynamicCost {
   // Elevation/grade penalty (weighting applied based on the edge's weighted
   // grade (relative value from 0-15)
   float grade_penalty[16];
-
-  // Threshold above which speed based penalties apply (based on the useroads
-  // factor).
-  uint32_t speed_penalty_threshold_;
-  float speed_factor_;
 
  public:
 
@@ -464,12 +465,13 @@ BicycleCost::BicycleCost(const boost::property_tree::ptree& pt)
   // threshold is 70 kph (near 50 MPH).
   speed_penalty_threshold_ = kSpeedPenaltyThreshold +
       static_cast<uint32_t>(useroads_ * 30.0f);
-  speed_factor_ = 1.1f / static_cast<float>(speed_penalty_threshold_);
 
-  // Create speed cost table (to avoid division in costing)
+  // Create speed cost table and penalty table (to avoid division in costing)
   speedfactor_[0] = kSecPerHour;
   for (uint32_t s = 1; s < 100; s++) {
     speedfactor_[s] = (kSecPerHour * 0.001f) / static_cast<float>(s);
+    speedpenalty_[s] = (s <= speed_penalty_threshold_) ? 1.0f :
+          powf(static_cast<float>(s) / static_cast<float>(speed_penalty_threshold_), 0.25);
   }
 
   // Populate the grade penalties (based on use_hills factor).
@@ -477,6 +479,7 @@ BicycleCost::BicycleCost(const boost::property_tree::ptree& pt)
   float avoidhills = (1.0f - usehills);
   for (uint32_t i = 0; i <= kMaxGradeFactor; i++) {
     grade_penalty[i] = 1.0f + avoidhills * kAvoidHillsStrength[i];
+LOG_INFO(std::to_string(i) + " Grade Penalty = " + std::to_string(grade_penalty[i] ));
   }
 }
 
@@ -492,9 +495,10 @@ bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
   // TODO - obtain and check the access restrictions.
 
   // Check bicycle access and turn restrictions. Bicycles should obey
-  // vehicular turn restrictions. Disallow Uturns. Skip impassable edges.
+  // vehicular turn restrictions. Allow Uturns at dead ends only.
+  // Skip impassable edges.
   if (!(edge->forwardaccess() & kBicycleAccess) ||
-      (pred.opp_local_idx() == edge->localedgeidx()) ||
+      (pred.opp_local_idx() == edge->localedgeidx() && !pred.deadend()) ||
       (pred.restrictions() & (1 << edge->localedgeidx()))) {
     return false;
   }
@@ -512,9 +516,9 @@ bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const baldr::GraphId& edgeid) const {
   // TODO - obtain and check the access restrictions.
 
-  // Check access, U-turn, and simple turn restriction.
+  // Check access, U-turn (allow at dead-ends), and simple turn restriction.
   if (!(opp_edge->forwardaccess() & kBicycleAccess) ||
-       (pred.opp_local_idx() == edge->localedgeidx()) ||
+       (pred.opp_local_idx() == edge->localedgeidx() && !pred.deadend()) ||
        (opp_edge->restrictions() & (1 << pred.opp_local_idx()))) {
     return false;
   }
@@ -547,9 +551,9 @@ Cost BicycleCost::EdgeCost(const baldr::DirectedEdge* edge,
   // Update speed based on surface factor. Lower speed for rougher surfaces
   // depending on the bicycle type. Modulate speed based on weighted grade
   // (relative measure of elevation change along the edge)
-  float speed = speed_ *
+  uint32_t bike_speed = static_cast<uint32_t>((speed_ *
                 surface_speed_factor_[static_cast<uint32_t>(edge->surface())] *
-		            kGradeBasedSpeedFactor[edge->weighted_grade()];
+		            kGradeBasedSpeedFactor[edge->weighted_grade()]) + 0.5f);
 
   // Apply a weighting factor to the cost based on desirability of cycling
   // on this edge. Based on several factors: rider propensity to ride on roads,
@@ -559,6 +563,7 @@ Cost BicycleCost::EdgeCost(const baldr::DirectedEdge* edge,
   float factor = 1.0f;
 
   // Special use cases: cycleway and footway
+  uint32_t road_speed = static_cast<uint32_t>(edge->speed() + 0.5f);
   if (edge->use() == Use::kCycleway) {
     // Experienced cyclists might not favor cycleways, but most do...
     factor = (0.5f + useroads_ * 0.5f);
@@ -573,39 +578,33 @@ Cost BicycleCost::EdgeCost(const baldr::DirectedEdge* edge,
     // Heavily penalize driveways
     factor = kDrivewayFactor;
   } else {
-    // On a road - set a cost factor based on useroads factor and road
-    // classification.
-    factor += (road_factor_ *
-              kRoadClassFactor[static_cast<uint32_t>(edge->classification())]);
-
-    // Add a penalty for higher speed roads above a threshold that
-    // depends on the useroads factor.
-    if (edge->speed() > speed_penalty_threshold_) {
-      factor *= static_cast<float>(edge->speed()) * speed_factor_;
-    }
-
-    // Favor roads where a cycle lane exists
+    // Favor roads where a cycle lane exists - if the lane is not separated
+    // apply the speed penalty
     if (edge->cyclelane() == CycleLane::kShared) {
-      factor *= 0.9f;
+      factor = 0.9f * speedpenalty_[road_speed];
     } else if (edge->cyclelane() == CycleLane::kDedicated) {
-      factor *= 0.8f;
+      factor = 0.8f * speedpenalty_[road_speed];
     } else if (edge->cyclelane() == CycleLane::kSeparated) {
       factor *= 0.7f;
+    } else {
+      // On a road without a bicycle lane. Set factor to include any speed
+      // penalty and road class factor
+      factor = speedpenalty_[road_speed] +
+              (road_factor_ * kRoadClassFactor[static_cast<uint32_t>(edge->classification())]);
     }
-  }
 
-  // Favor bicycle networks.
-  // TODO - do we need to differentiate between types of network?
-  if (edge->bike_network() > 0) {
-    factor *= kBicycleNetworkFactor;
+    // Favor bicycle networks.
+    // TODO - do we need to differentiate between types of network?
+    if (edge->bike_network() > 0) {
+      factor *= kBicycleNetworkFactor;
+    }
   }
 
   // Update factor based on penalties applied for weighted_grade
-  // TODO - do we need to modulate by length?
   factor *= grade_penalty[edge->weighted_grade()];
 
   // Compute elapsed time based on speed. Modulate cost with weighting factors.
-  float sec = (edge->length() * speedfactor_[static_cast<uint32_t>(speed + 0.5f)]);
+  float sec = (edge->length() * speedfactor_[bike_speed]);
   return { sec * factor, sec };
 }
 
@@ -641,6 +640,13 @@ Cost BicycleCost::TransitionCost(const baldr::DirectedEdge* edge,
   }
   if (!node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
+  }
+
+  // Penalize transition to higher class road.
+  // TODO - modulate based on useroads factor?
+  if (edge->classification() < pred.classification()) {
+    penalty += 10.0f * (static_cast<uint32_t>(pred.classification()) -
+                        static_cast<uint32_t>(edge->classification()));
   }
 
   // Transition time = densityfactor * stopimpact * turncost
@@ -696,6 +702,13 @@ Cost BicycleCost::TransitionCostReverse(const uint32_t idx,
   }
   if (!node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
+  }
+
+  // Penalize transition to higher class road.
+  // TODO - modulate based on useroads factor?
+  if (edge->classification() < pred->classification()) {
+    penalty += 10.0f * (static_cast<uint32_t>(pred->classification()) -
+                        static_cast<uint32_t>(edge->classification()));
   }
 
   // Transition time = densityfactor * stopimpact * turncost

--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -18,7 +18,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
                      const uint32_t restrictions,
                      const uint32_t opp_local_idx,
                      const TravelMode mode, const uint32_t path_distance)
-    : edgeid_(edgeid),
+    : predecessor_(predecessor),
+      edgeid_(edgeid),
       opp_edgeid_ {},
       endnode_(edge->endnode()),
       cost_(cost),
@@ -37,13 +38,14 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       has_transit_(0),
       origin_(0),
       toll_(edge->toll()),
-      predecessor_(predecessor),
+      classification_(static_cast<uint32_t>(edge->classification())),
       tripid_(0),
       blockid_(0),
       transit_operator_(0),
       transition_cost_(0),
       transition_secs_(0),
-      not_thru_(edge->not_thru())  {
+      not_thru_(edge->not_thru()),
+      deadend_(edge->deadend()) {
 }
 
 // Constructor with values - used in bidirectional A*
@@ -53,7 +55,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
                      const uint32_t restrictions,
                      const uint32_t opp_local_idx,
                      const TravelMode mode, const Cost& tc)
-    : edgeid_(edgeid),
+    : predecessor_(predecessor),
+      edgeid_(edgeid),
       opp_edgeid_(oppedgeid),
       endnode_(edge->endnode()),
       cost_(cost),
@@ -72,13 +75,14 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       has_transit_(0),
       origin_(0),
       toll_(edge->toll()),
-      predecessor_(predecessor),
+      classification_(static_cast<uint32_t>(edge->classification())),
       tripid_(0),
       blockid_(0),
       transit_operator_(0),
       transition_cost_(tc.cost),
       transition_secs_(tc.secs),
-      not_thru_(edge->not_thru())  {
+      not_thru_(edge->not_thru()),
+      deadend_(edge->deadend()) {
 }
 
 // Constructor with values.  Used for multi-modal path.
@@ -90,7 +94,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
           const uint32_t tripid, const GraphId& prior_stopid,
           const uint32_t blockid, const uint32_t transit_operator,
           const bool has_transit)
-    : edgeid_(edgeid),
+    : predecessor_(predecessor),
+      edgeid_(edgeid),
       opp_edgeid_(prior_stopid),
       endnode_(edge->endnode()),
       cost_(cost),
@@ -109,13 +114,14 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       has_transit_(has_transit),
       origin_(0),
       toll_(edge->toll()),
-      predecessor_(predecessor),
+      classification_(static_cast<uint32_t>(edge->classification())),
       tripid_(tripid),
       blockid_(blockid),
       transit_operator_(transit_operator),
       transition_cost_(0),
       transition_secs_(0),
-      not_thru_(edge->not_thru()) {
+      not_thru_(edge->not_thru()),
+      deadend_(edge->deadend()) {
 }
 
 // Constructor with values - used in time distance matrix (needs the
@@ -126,7 +132,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
                 const Cost& cost, const uint32_t restrictions,
                 const uint32_t opp_local_idx, const TravelMode mode,
                 const Cost& tc, const uint32_t path_distance)
-    :  edgeid_(edgeid),
+    :  predecessor_(predecessor),
+       edgeid_(edgeid),
        opp_edgeid_(oppedgeid),
        endnode_(edge->endnode()),
        cost_(cost),
@@ -145,13 +152,14 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
        has_transit_(0),
        origin_(0),
        toll_(edge->toll()),
-       predecessor_(predecessor),
+       classification_(static_cast<uint32_t>(edge->classification())),
        tripid_(0),
        blockid_(0),
        transit_operator_(0),
        transition_cost_(tc.cost),
        transition_secs_(tc.secs),
-       not_thru_(edge->not_thru()) {
+       not_thru_(edge->not_thru()),
+       deadend_(edge->deadend()) {
 }
 
 // Update predecessor and cost values in the label.
@@ -308,6 +316,11 @@ uint32_t EdgeLabel::path_distance() const {
   return path_distance_;
 }
 
+// Get the predecessor road classification.
+RoadClass EdgeLabel::classification() const {
+  return static_cast<RoadClass>(classification_);
+}
+
 // Get the transit trip Id.
 uint32_t EdgeLabel::tripid() const {
   return tripid_;
@@ -351,6 +364,11 @@ bool EdgeLabel::not_thru() const {
 // Set the not-through flag for this edge.
 void EdgeLabel::set_not_thru(const bool not_thru) {
   not_thru_ = not_thru;
+}
+
+// Is this edge a dead end.
+bool EdgeLabel::deadend() const {
+  return deadend_;
 }
 
 // Operator for sorting.

--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -38,7 +38,6 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       has_transit_(0),
       origin_(0),
       toll_(edge->toll()),
-      classification_(static_cast<uint32_t>(edge->classification())),
       tripid_(0),
       blockid_(0),
       transit_operator_(0),
@@ -75,7 +74,6 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       has_transit_(0),
       origin_(0),
       toll_(edge->toll()),
-      classification_(static_cast<uint32_t>(edge->classification())),
       tripid_(0),
       blockid_(0),
       transit_operator_(0),
@@ -114,7 +112,6 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       has_transit_(has_transit),
       origin_(0),
       toll_(edge->toll()),
-      classification_(static_cast<uint32_t>(edge->classification())),
       tripid_(tripid),
       blockid_(blockid),
       transit_operator_(transit_operator),
@@ -152,7 +149,6 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
        has_transit_(0),
        origin_(0),
        toll_(edge->toll()),
-       classification_(static_cast<uint32_t>(edge->classification())),
        tripid_(0),
        blockid_(0),
        transit_operator_(0),
@@ -314,11 +310,6 @@ uint32_t EdgeLabel::opp_index() const {
 // Get the current accumulated path distance in meters.
 uint32_t EdgeLabel::path_distance() const {
   return path_distance_;
-}
-
-// Get the predecessor road classification.
-RoadClass EdgeLabel::classification() const {
-  return static_cast<RoadClass>(classification_);
 }
 
 // Get the transit trip Id.

--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -74,6 +74,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       has_transit_(0),
       origin_(0),
       toll_(edge->toll()),
+      classification_(static_cast<uint32_t>(edge->classification())),
       tripid_(0),
       blockid_(0),
       transit_operator_(0),
@@ -112,6 +113,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       has_transit_(has_transit),
       origin_(0),
       toll_(edge->toll()),
+      classification_(static_cast<uint32_t>(edge->classification())),
       tripid_(tripid),
       blockid_(blockid),
       transit_operator_(transit_operator),
@@ -149,6 +151,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
        has_transit_(0),
        origin_(0),
        toll_(edge->toll()),
+       classification_(static_cast<uint32_t>(edge->classification())),
        tripid_(0),
        blockid_(0),
        transit_operator_(0),
@@ -310,6 +313,11 @@ uint32_t EdgeLabel::opp_index() const {
 // Get the current accumulated path distance in meters.
 uint32_t EdgeLabel::path_distance() const {
   return path_distance_;
+}
+
+// Get the predecessor road classification.
+RoadClass EdgeLabel::classification() const {
+  return static_cast<RoadClass>(classification_);
 }
 
 // Get the transit trip Id.

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -309,12 +309,6 @@ class EdgeLabel {
   uint32_t path_distance() const;
 
   /**
-   * Get the predecessor road classification.
-   * @return Predecessor road classification.
-   */
-  baldr::RoadClass classification() const;
-
-  /**
    * Get the transit trip Id.
    * @return   Returns the transit trip Id of the prior edge.
    */
@@ -434,12 +428,8 @@ class EdgeLabel {
   // predecessor_:     Index to the predecessor edge label information.
   uint32_t predecessor_;
 
-  /**
-   * tripid_:          Transit trip Id.
-   * classification_ : Classification of edge.
-   */
-  uint32_t tripid_           : 28;
-  uint32_t classification_   : 4;
+  // tripid_:          Transit trip Id.
+  uint32_t tripid_;
 
   // Block Id and prior operator (index to an internal mapping).
   // 0 indicates no prior.

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -309,6 +309,12 @@ class EdgeLabel {
   uint32_t path_distance() const;
 
   /**
+   * Get the predecessor road classification.
+   * @return Predecessor road classification.
+   */
+  baldr::RoadClass classification() const;
+
+  /**
    * Get the transit trip Id.
    * @return   Returns the transit trip Id of the prior edge.
    */
@@ -365,6 +371,12 @@ class EdgeLabel {
    */
   void set_not_thru(const bool not_thru);
 
+  /**
+   * Is this edge a dead end.
+   * @return  Returns true if the edge is a dead end.
+   */
+  bool deadend() const;
+
  private:
   // Graph Id of the edge.
   baldr::GraphId edgeid_;
@@ -419,21 +431,32 @@ class EdgeLabel {
   uint64_t origin_           : 1;
   uint64_t toll_             : 1;
 
-  // Index to the predecessor edge label information.
+  // predecessor_:     Index to the predecessor edge label information.
   uint32_t predecessor_;
 
-  // Transit trip Id
-  uint32_t tripid_;
+  /**
+   * tripid_:          Transit trip Id.
+   * classification_ : Classification of edge.
+   */
+  uint32_t tripid_           : 28;
+  uint32_t classification_   : 4;
 
   // Block Id and prior operator (index to an internal mapping).
   // 0 indicates no prior.
-  uint32_t blockid_          : 22;
+  uint32_t blockid_          : 20;
   uint32_t transit_operator_ : 10;
+  uint32_t spare_            : 2;
 
-  // Transition cost (used in bidirectional path search).
-  uint32_t transition_cost_ : 16;
+  /**
+   * transition_cost_: Transition cost (used in bidirectional path search).
+   * transition_secs_: Transition time (used in bidirectional path search).
+   * not_thru_:        Flag indicating edge is not_thru.
+   * deadend_:         Flag indicating edge is a deadend.
+   */
+  uint32_t transition_cost_ : 15;
   uint32_t transition_secs_ : 15;
   uint32_t not_thru_        : 1;
+  uint32_t deadend_         : 1;
 };
 
 }

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -309,6 +309,12 @@ class EdgeLabel {
   uint32_t path_distance() const;
 
   /**
+   * Get the predecessor road classification.
+   * @return Predecessor road classification.
+   */
+  baldr::RoadClass classification() const;
+
+  /**
    * Get the transit trip Id.
    * @return   Returns the transit trip Id of the prior edge.
    */
@@ -426,16 +432,19 @@ class EdgeLabel {
   uint64_t toll_             : 1;
 
   // predecessor_:     Index to the predecessor edge label information.
+  // Note: invalid predecessor value uses all 32 bits (so if this needs to
+  // be part of a bit field make sure kInvalidLabel is changed.
   uint32_t predecessor_;
 
   // tripid_:          Transit trip Id.
-  uint32_t tripid_;
+  // classification_:  Road classification
+  uint32_t tripid_           : 29;
+  uint32_t classification_   : 3;
 
   // Block Id and prior operator (index to an internal mapping).
   // 0 indicates no prior.
-  uint32_t blockid_          : 20;
+  uint32_t blockid_          : 22; // Really only needs 20 bits
   uint32_t transit_operator_ : 10;
-  uint32_t spare_            : 2;
 
   /**
    * transition_cost_: Transition cost (used in bidirectional path search).


### PR DESCRIPTION
May want to also do this for others. This is needed since location heading can select an edge leading to a dead-end, rather than an outbound edge.