### PR TITLE
Add flag for not_thru_pruning. 

### DIFF
--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -1,6 +1,8 @@
 #include <string.h>
 #include "sif/edgelabel.h"
 
+#include <valhalla/midgard/logging.h>
+
 using namespace valhalla::baldr;
 
 namespace valhalla {
@@ -38,12 +40,14 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       has_transit_(0),
       origin_(0),
       toll_(edge->toll()),
+      classification_(static_cast<uint32_t>(edge->classification())),
       tripid_(0),
       blockid_(0),
       transit_operator_(0),
       transition_cost_(0),
       transition_secs_(0),
       not_thru_(edge->not_thru()),
+      not_thru_pruning_(false),
       deadend_(edge->deadend()) {
 }
 
@@ -51,9 +55,9 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
 EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
                      const GraphId& oppedgeid, const DirectedEdge* edge,
                      const Cost& cost, const float sortcost, const float dist,
-                     const uint32_t restrictions,
-                     const uint32_t opp_local_idx,
-                     const TravelMode mode, const Cost& tc)
+                     const uint32_t restrictions, const uint32_t opp_local_idx,
+                     const TravelMode mode, const Cost& tc,
+                     bool not_thru_pruning)
     : predecessor_(predecessor),
       edgeid_(edgeid),
       opp_edgeid_(oppedgeid),
@@ -81,6 +85,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       transition_cost_(tc.cost),
       transition_secs_(tc.secs),
       not_thru_(edge->not_thru()),
+      not_thru_pruning_(not_thru_pruning),
       deadend_(edge->deadend()) {
 }
 
@@ -120,6 +125,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       transition_cost_(0),
       transition_secs_(0),
       not_thru_(edge->not_thru()),
+      not_thru_pruning_(false),
       deadend_(edge->deadend()) {
 }
 
@@ -130,7 +136,8 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
                 const GraphId& oppedgeid, const DirectedEdge* edge,
                 const Cost& cost, const uint32_t restrictions,
                 const uint32_t opp_local_idx, const TravelMode mode,
-                const Cost& tc, const uint32_t path_distance)
+                const Cost& tc, const uint32_t path_distance,
+                bool not_thru_pruning)
     :  predecessor_(predecessor),
        edgeid_(edgeid),
        opp_edgeid_(oppedgeid),
@@ -158,6 +165,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
        transition_cost_(tc.cost),
        transition_secs_(tc.secs),
        not_thru_(edge->not_thru()),
+       not_thru_pruning_(not_thru_pruning),
        deadend_(edge->deadend()) {
 }
 
@@ -318,6 +326,11 @@ uint32_t EdgeLabel::path_distance() const {
 // Get the predecessor road classification.
 RoadClass EdgeLabel::classification() const {
   return static_cast<RoadClass>(classification_);
+}
+
+// Should not thru pruning be enabled on this path?
+bool EdgeLabel::not_thru_pruning() const {
+  return not_thru_pruning_;
 }
 
 // Get the transit trip Id.

--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -1,8 +1,6 @@
 #include <string.h>
 #include "sif/edgelabel.h"
 
-#include <valhalla/midgard/logging.h>
-
 using namespace valhalla::baldr;
 
 namespace valhalla {

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -44,7 +44,7 @@ class EdgeLabel {
             const TravelMode mode, const uint32_t path_distance);
 
   /**
-   * Constructor with values - used in bidrectional A*.
+   * Constructor with values - used in bidirectional A*.
    * @param predecessor  Index into the edge label list for the predecessor
    *                     directed edge in the shortest path.
    * @param edgeid       Directed edge.
@@ -58,13 +58,15 @@ class EdgeLabel {
    *                     to be carried across different hierarchy levels.
    * @param mode         Mode of travel along this edge.
    * @param tc           Transition cost entering this edge.
+   * @param not_thru_pruning  Is not thru pruning enabled.
    */
   EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
             const baldr::GraphId& oppedgeid,
             const baldr::DirectedEdge* edge, const Cost& cost,
             const float sortcost, const float dist,
             const uint32_t restrictions, const uint32_t opp_local_idx,
-            const TravelMode mode, const Cost& tc);
+            const TravelMode mode, const Cost& tc,
+            bool not_thru_pruning);
 
   /**
    * Constructor with values.  Used for multi-modal path.
@@ -112,13 +114,14 @@ class EdgeLabel {
    * @param mode          Mode of travel along this edge.
    * @param tc            Transition cost entering this edge.
    * @param path_distance Accumulated path distance.
+   * @param not_thru_pruning  Is not thru pruning enabled.
    */
   EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
             const baldr::GraphId& oppedgeid,
             const baldr::DirectedEdge* edge, const Cost& cost,
             const uint32_t restrictions, const uint32_t opp_local_idx,
             const TravelMode mode, const Cost& tc,
-            const uint32_t path_distance);
+            const uint32_t path_distance, bool not_thru_pruning);
 
   /**
    * Update an existing edge label with new predecessor and cost information.
@@ -313,6 +316,12 @@ class EdgeLabel {
   baldr::RoadClass classification() const;
 
   /**
+   * Should not thru pruning be enabled on this path?
+   * @return Returns true if not thru pruning should be enabled.
+   */
+  bool not_thru_pruning() const;
+
+  /**
    * Get the transit trip Id.
    * @return   Returns the transit trip Id of the prior edge.
    */
@@ -436,8 +445,10 @@ class EdgeLabel {
 
   // tripid_:          Transit trip Id.
   // classification_:  Road classification
-  uint32_t tripid_           : 29;
+  // not_thru_pruning_:Is not thru pruning enabled?
+  uint32_t tripid_           : 28;
   uint32_t classification_   : 3;
+  uint32_t not_thru_pruning_ : 1;
 
   // Block Id and prior operator (index to an internal mapping).
   // 0 indicates no prior.


### PR DESCRIPTION
This needs to be state that is passed in from the path algorithm. Once a thru edge is encountered on a path the not_thru_pruning flag is enabled. This fixes paths were both origin and destination are inside disconnected regions or places where both directions are marked as not_thru.