### PR TITLE
Add support for complex restrictions.

### DIFF
--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -1,6 +1,56 @@
 #include "sif/dynamiccost.h"
+#include <valhalla/baldr/double_bucket_queue.h> // For kInvalidLabel
 
 using namespace valhalla::baldr;
+
+namespace {
+
+using namespace valhalla::sif;
+
+// Check for complex restriction
+bool IsRestricted(const EdgeLabel& pred, const std::vector<EdgeLabel>& edge_labels,
+                  const std::vector<ComplexRestriction>& restrictions,
+                  const bool forward) {
+  // Lambda to get the next predecessor EdgeLabel (that is not a transition)
+  auto next_predecessor = [&edge_labels](const EdgeLabel* label) {
+    // Get the next predecessor - make sure it is valid. Continue to get
+    // the next predecessor if the edge is a transition edge.
+    const EdgeLabel* next_pred = (label->predecessor() == kInvalidLabel) ?
+                    label : &edge_labels[label->predecessor()];
+    while (next_pred->use() == Use::kTransitionUp &&
+           next_pred->predecessor() != kInvalidLabel) {
+      next_pred = &edge_labels[next_pred->predecessor()];
+    }
+    return next_pred;
+  };
+
+  // Get the first predecessor edge (that is not a transition)
+  const EdgeLabel* first_pred = &pred;
+  if (first_pred->use() == Use::kTransitionUp) {
+    first_pred = next_predecessor(first_pred);
+  }
+
+  // Iterate through the restrictions
+  for (const auto& cr : restrictions) {
+    // Walk the via list, break if the via edge Ids do not match the path
+    const EdgeLabel* next_pred = first_pred;
+    for (const auto& via_id : cr.GetVias()) {
+      if (via_id != next_pred->edgeid()) {
+        return false;
+      }
+      next_pred = next_predecessor(next_pred);
+    }
+
+    // Check against the start/end of the complex restriction
+    if (( forward && next_pred->edgeid() == cr.from_id()) ||
+        (!forward && next_pred->edgeid() == cr.to_id())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}
 
 namespace valhalla{
 namespace sif {
@@ -56,6 +106,32 @@ Cost DynamicCost::TransitionCostReverse(const uint32_t idx,
                             const baldr::DirectedEdge* opp_edge,
                             const baldr::DirectedEdge* opp_pred_edge) const {
   return { 0.0f, 0.0f };
+}
+
+/**
+ * Test if an edge should be restricted due to a complex restriction.
+ */
+bool DynamicCost::Restricted(const DirectedEdge* edge,
+                             const EdgeLabel& pred,
+                             const std::vector<EdgeLabel>& edgelabels,
+                             const baldr::GraphTile*& tile,
+                             const baldr::GraphId& edgeid,
+                             const bool forward) const {
+  // If forward, check if the edge marks the end of a restriction, else check
+  // if the edge marks the start of a complex restriction.
+  bool has_restriction = (forward) ?
+      edge->end_restriction()   & access_mode() :
+      edge->start_restriction() & access_mode();
+  if (has_restriction) {
+    // Get complex restrictions. Return false if no restrictions are found
+    auto restrictions = tile->GetRestrictions(forward, edgeid, access_mode());
+    if (restrictions.size() == 0) {
+      return false;
+    }
+    return IsRestricted(pred, edgelabels, restrictions, forward);
+  } else {
+    return false;
+  }
 }
 
 // Returns the transfer cost between 2 transit stops.

--- a/src/sif/edgelabel.cc
+++ b/src/sif/edgelabel.cc
@@ -40,6 +40,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       transit_operator_(0),
       transition_cost_(0),
       transition_secs_(0),
+      on_complex_rest_(edge->part_of_complex_restriction()),
       not_thru_(edge->not_thru()),
       not_thru_pruning_(false),
       deadend_(edge->deadend()) {
@@ -75,6 +76,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       transit_operator_(0),
       transition_cost_(tc.cost),
       transition_secs_(tc.secs),
+      on_complex_rest_(edge->part_of_complex_restriction()),
       not_thru_(edge->not_thru()),
       not_thru_pruning_(not_thru_pruning),
       deadend_(edge->deadend()) {
@@ -112,6 +114,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       transit_operator_(transit_operator),
       transition_cost_(0),
       transition_secs_(0),
+      on_complex_rest_(edge->part_of_complex_restriction()),
       not_thru_(edge->not_thru()),
       not_thru_pruning_(false),
       deadend_(edge->deadend()) {
@@ -149,6 +152,7 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
        transit_operator_(0),
        transition_cost_(tc.cost),
        transition_secs_(tc.secs),
+       on_complex_rest_(edge->part_of_complex_restriction()),
        not_thru_(edge->not_thru()),
        not_thru_pruning_(not_thru_pruning),
        deadend_(edge->deadend()) {
@@ -357,6 +361,11 @@ uint32_t EdgeLabel::transition_secs() const {
 void EdgeLabel::set_transition_cost(const Cost& tc) {
   transition_cost_ = tc.cost;
   transition_secs_ = tc.secs;
+}
+
+// Is this edge part of a complex restriction.
+bool EdgeLabel::on_complex_rest() const {
+  return on_complex_rest_;
 }
 
 // Is this edge not-through

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -191,6 +191,25 @@ class DynamicCost {
                               const baldr::DirectedEdge* opp_pred_edge) const;
 
   /**
+   * Test if an edge should be restricted due to a complex restriction.
+   * @param  edge  Directed edge.
+   * @param  pred        Predecessor information.
+   * @param  edgelabels  List of edge labels.
+   * @param  tile        Graph tile (to read restriction if needed).
+   * @param  edgeid      Edge Id for the directed edge.
+   * @param  forward     Forward search or reverse search.
+   * @return Returns true it there is a complex restriction onto this edge
+   *         that matches the mode and the predecessor list for the current
+   *         path matches a complex restriction.
+   */
+  virtual bool Restricted(const baldr::DirectedEdge* edge,
+                          const EdgeLabel& pred,
+                          const std::vector<EdgeLabel>& edgelabels,
+                          const baldr::GraphTile*& tile,
+                          const baldr::GraphId& edgeid,
+                          const bool forward) const;
+
+  /**
    * Returns the transfer cost between 2 transit stops.
    * @return  Returns the transfer cost and time (seconds).
    */

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -350,6 +350,12 @@ class EdgeLabel {
   void set_transition_cost(const Cost& tc);
 
   /**
+   * Is this edge part of a complex restriction.
+   * @return  Returns true if the edge is part of a complex restriction.
+   */
+  bool on_complex_rest() const;
+
+  /**
    * Is this edge not-through
    * @return  Returns true if the edge is not thru.
    */
@@ -441,9 +447,11 @@ class EdgeLabel {
   /**
    * transition_cost_: Transition cost (used in bidirectional path search).
    * transition_secs_: Transition time (used in bidirectional path search).
+   * on_complex_rest_: Edge is part of a complex restriction.
    */
   uint32_t transition_cost_ : 16;
-  uint32_t transition_secs_ : 16;
+  uint32_t transition_secs_ : 15;
+  uint32_t on_complex_rest_ : 1;
 };
 
 }


### PR DESCRIPTION
If the edge starts/ends (based on the search direction) it looks up the restrictions and walks the predecessor edge label to see if the predecessor path matches the restriction edges.