### PR TITLE
Add support for DisableDestinationOnly

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -73,6 +73,13 @@ class AutoCost : public DynamicCost {
   virtual bool AllowMultiPass() const;
 
   /**
+   * Disables entrance into destination only areas. This should only be used
+   * for bidirectional path algorithms (and generally only for driving),
+   * otherwise a destination only penalty should be used.
+   */
+  virtual void DisableDestinationOnly();
+
+  /**
    * Get the access mode used by this costing method.
    * @return  Returns access mode.
    */
@@ -305,6 +312,12 @@ bool AutoCost::AllowMultiPass() const {
   return true;
 }
 
+// Set to disable destination only transitions.
+void AutoCost::DisableDestinationOnly() {
+  disable_destination_only_ = true;
+  destination_only_penalty_ = 0;
+}
+
 // Get the access mode used by this costing method.
 uint32_t AutoCost::access_mode() const {
   return kAutoAccess;
@@ -324,7 +337,8 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
   if (!(edge->forwardaccess() & kAutoAccess) ||
       (pred.opp_local_idx() == edge->localedgeidx() && !pred.deadend()) ||
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
-       edge->surface() == Surface::kImpassable) {
+       edge->surface() == Surface::kImpassable ||
+      (disable_destination_only_ && !pred.destonly() && edge->destonly())) {
     return false;
   }
   return true;
@@ -344,7 +358,8 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
   if (!(opp_edge->forwardaccess() & kAutoAccess) ||
        (pred.opp_local_idx() == edge->localedgeidx() && !pred.deadend()) ||
        (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
-        opp_edge->surface() == Surface::kImpassable) {
+        opp_edge->surface() == Surface::kImpassable ||
+       (disable_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
     return false;
   }
   return true;
@@ -689,7 +704,8 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
   if (!(edge->forwardaccess() & kBusAccess) ||
       (pred.opp_local_idx() == edge->localedgeidx() && !pred.deadend()) ||
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
-       edge->surface() == Surface::kImpassable) {
+       edge->surface() == Surface::kImpassable ||
+      (disable_destination_only_ && !pred.destonly() && edge->destonly())) {
     return false;
   }
   return true;
@@ -709,7 +725,8 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
   if (!(opp_edge->forwardaccess() & kBusAccess) ||
        (pred.opp_local_idx() == edge->localedgeidx() && !pred.deadend()) ||
        (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
-        opp_edge->surface() == Surface::kImpassable) {
+        opp_edge->surface() == Surface::kImpassable ||
+       (disable_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
     return false;
   }
   return true;

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -58,6 +58,7 @@ namespace sif {
 DynamicCost::DynamicCost(const boost::property_tree::ptree& pt,
                          const TravelMode mode)
     : allow_transit_connections_(false),
+      disable_destination_only_(false),
       travel_mode_(mode) {
   // Parse property tree to get hierarchy limits
   // TODO - get the number of levels
@@ -153,6 +154,11 @@ uint32_t DynamicCost::UnitSize() const {
 // Set to allow use of transit connections.
 void DynamicCost::SetAllowTransitConnections(const bool allow) {
   allow_transit_connections_ = allow;
+}
+
+// Set to allow use of transit connections.
+void DynamicCost::DisableDestinationOnly() {
+  disable_destination_only_ = true;
 }
 
 // Returns the maximum transfer distance between stops that you are willing

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -95,6 +95,13 @@ class TruckCost : public DynamicCost {
   virtual bool AllowMultiPass() const;
 
   /**
+   * Disables entrance into destination only areas. This should only be used
+   * for bidirectional path algorithms (and generally only for driving),
+   * otherwise a destination only penalty should be used.
+   */
+  virtual void DisableDestinationOnly();
+
+  /**
    * Get the access mode used by this costing method.
    * @return  Returns access mode.
    */
@@ -313,6 +320,12 @@ bool TruckCost::AllowMultiPass() const {
   return true;
 }
 
+// Set to disable destination only transitions.
+void TruckCost::DisableDestinationOnly() {
+  disable_destination_only_ = true;
+  destination_only_penalty_ = 0;
+}
+
 // Get the access mode used by this costing method.
 uint32_t TruckCost::access_mode() const {
   return kTruckAccess;
@@ -328,7 +341,8 @@ bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
   if (!(edge->forwardaccess() & kTruckAccess) ||
       (pred.opp_local_idx() == edge->localedgeidx()) ||
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
-       edge->surface() == Surface::kImpassable) {
+       edge->surface() == Surface::kImpassable ||
+      (disable_destination_only_ && !pred.destonly() && edge->destonly())) {
     return false;
   }
 
@@ -385,7 +399,8 @@ bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
   if (!(opp_edge->forwardaccess() & kTruckAccess) ||
        (pred.opp_local_idx() == edge->localedgeidx()) ||
        (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
-       opp_edge->surface() == Surface::kImpassable) {
+       opp_edge->surface() == Surface::kImpassable ||
+      (disable_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
     return false;
   }
 

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -245,6 +245,13 @@ class DynamicCost {
   virtual uint32_t UnitSize() const;
 
   /**
+   * Disables entrance into destination only areas. This should only be used
+   * for bidirectional path algorithms (and generally only for driving),
+   * otherwise a destination only penalty should be used.
+   */
+  virtual void DisableDestinationOnly();
+
+  /**
    * Set to allow use of transit connections.
    * @param  allow  Flag indicating whether transit connections are allowed.
    */
@@ -328,6 +335,9 @@ class DynamicCost {
  protected:
   // Flag indicating whether transit connections are allowed.
   bool allow_transit_connections_;
+
+  // Disable entrance onto destination only edges
+  bool disable_destination_only_;
 
   // Travel mode
   TravelMode travel_mode_;


### PR DESCRIPTION
For driving routes within bidirectional path algorithms this will prohibit entering a destination only edge. This is more effective than setting penalties to avoid shortcuts through destination only areas. 

This is with prior logic using a penalty - it takes a shortcut through a parking area:

![destinationonly1](https://cloud.githubusercontent.com/assets/1838768/20714523/449b3ba4-b61a-11e6-8ebd-93ba8a21965d.png)

This is with new logic - it now takes service roads without cutting though parking aisles:

![destinationonly2](https://cloud.githubusercontent.com/assets/1838768/20714550/57e8cc80-b61a-11e6-8ab6-59d4a325d675.png)

