### PR TITLE
Ignore name inconsistency when entering a link to avoid double penalizing

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -417,7 +417,8 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
     seconds += ferry_cost_;
     penalty += ferry_penalty_;
   }
-  if (!node->name_consistency(idx, edge->localedgeidx())) {
+  // Ignore name inconsistency when entering a link to avoid double penalizing.
+  if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
   }
 
@@ -477,7 +478,8 @@ Cost AutoCost::TransitionCostReverse(const uint32_t idx,
     seconds += ferry_cost_;
     penalty += ferry_penalty_;
   }
-  if (!node->name_consistency(idx, edge->localedgeidx())) {
+  // Ignore name inconsistency when entering a link to avoid double penalizing.
+  if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
   }
 

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -155,16 +155,14 @@ class AutoCost : public DynamicCost {
    * when using a reverse search (from destination towards the origin).
    * @param  idx   Directed edge local index
    * @param  node  Node (intersection) where transition occurs.
-   * @param  opp_edge  Pointer to the opposing directed edge - this is the
-   *                   "from" or predecessor edge in the transition.
-   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
-   *                        predecessor. This is the "to" edge.
+   * @param  pred  the opposing current edge in the reverse tree.
+   * @param  edge  the opposing predecessor in the reverse tree
    * @return  Returns the cost and time (seconds)
    */
-  virtual Cost TransitionCostReverse(const uint32_t idx,
-                              const baldr::NodeInfo* node,
-                              const baldr::DirectedEdge* opp_edge,
-                              const baldr::DirectedEdge* opp_pred_edge) const;
+  virtual Cost TransitionCostReverse(
+      const uint32_t idx, const baldr::NodeInfo* node,
+      const baldr::DirectedEdge* pred,
+      const baldr::DirectedEdge* edge) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -384,8 +382,8 @@ Cost AutoCost::EdgeCost(const DirectedEdge* edge) const {
 
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
-                               const baldr::NodeInfo* node,
-                               const EdgeLabel& pred) const {
+                              const baldr::NodeInfo* node,
+                              const EdgeLabel& pred) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;
@@ -419,6 +417,7 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
   }
   // Ignore name inconsistency when entering a link to avoid double penalizing.
   if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
+    // Slight maneuver penalty
     penalty += maneuver_penalty_;
   }
 
@@ -445,9 +444,9 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
 // pred is the opposing current edge in the reverse tree
 // edge is the opposing predecessor in the reverse tree
 Cost AutoCost::TransitionCostReverse(const uint32_t idx,
-                            const baldr::NodeInfo* node,
-                            const baldr::DirectedEdge* pred,
-                            const baldr::DirectedEdge* edge) const {
+                                     const baldr::NodeInfo* node,
+                                     const baldr::DirectedEdge* pred,
+                                     const baldr::DirectedEdge* edge) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;
@@ -480,6 +479,7 @@ Cost AutoCost::TransitionCostReverse(const uint32_t idx,
   }
   // Ignore name inconsistency when entering a link to avoid double penalizing.
   if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
+    // Slight maneuver penalty
     penalty += maneuver_penalty_;
   }
 

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -102,10 +102,10 @@ Cost DynamicCost::TransitionCost(const DirectedEdge* edge,
 // when using a reverse search (from destination towards the origin).
 // Defaults to 0. Costing models that wish to include edge transition
 // costs (i.e., intersection/turn costs) must override this method.
-Cost DynamicCost::TransitionCostReverse(const uint32_t idx,
-                            const baldr::NodeInfo* node,
-                            const baldr::DirectedEdge* opp_edge,
-                            const baldr::DirectedEdge* opp_pred_edge) const {
+Cost DynamicCost::TransitionCostReverse(
+    const uint32_t idx, const baldr::NodeInfo* node,
+    const baldr::DirectedEdge* opp_edge,
+    const baldr::DirectedEdge* opp_pred_edge) const {
   return { 0.0f, 0.0f };
 }
 

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -174,16 +174,14 @@ class TruckCost : public DynamicCost {
    * when using a reverse search (from destination towards the origin).
    * @param  idx   Directed edge local index
    * @param  node  Node (intersection) where transition occurs.
-   * @param  opp_edge  Pointer to the opposing directed edge - this is the
-   *                   "from" or predecessor edge in the transition.
-   * @param  opp_pred_edge  Pointer to the opposing directed edge to the
-   *                        predecessor. This is the "to" edge.
+   * @param  pred  the opposing current edge in the reverse tree.
+   * @param  edge  the opposing predecessor in the reverse tree
    * @return  Returns the cost and time (seconds)
    */
-  virtual Cost TransitionCostReverse(const uint32_t idx,
-                              const baldr::NodeInfo* node,
-                              const baldr::DirectedEdge* opp_edge,
-                              const baldr::DirectedEdge* opp_pred_edge) const;
+  virtual Cost TransitionCostReverse(
+      const uint32_t idx, const baldr::NodeInfo* node,
+      const baldr::DirectedEdge* pred,
+      const baldr::DirectedEdge* edge) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -503,6 +501,7 @@ Cost TruckCost::TransitionCost(const baldr::DirectedEdge* edge,
   }
   // Ignore name inconsistency when entering a link to avoid double penalizing.
   if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
+    // Slight maneuver penalty
     penalty += maneuver_penalty_;
   }
 
@@ -533,9 +532,9 @@ Cost TruckCost::TransitionCost(const baldr::DirectedEdge* edge,
 // pred is the opposing current edge in the reverse tree
 // edge is the opposing predecessor in the reverse tree
 Cost TruckCost::TransitionCostReverse(const uint32_t idx,
-                            const baldr::NodeInfo* node,
-                            const baldr::DirectedEdge* pred,
-                            const baldr::DirectedEdge* edge) const {
+                                      const baldr::NodeInfo* node,
+                                      const baldr::DirectedEdge* pred,
+                                      const baldr::DirectedEdge* edge) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -501,7 +501,8 @@ Cost TruckCost::TransitionCost(const baldr::DirectedEdge* edge,
   if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
     penalty += alley_penalty_;
   }
-  if (!node->name_consistency(idx, edge->localedgeidx())) {
+  // Ignore name inconsistency when entering a link to avoid double penalizing.
+  if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
   }
 
@@ -561,7 +562,8 @@ Cost TruckCost::TransitionCostReverse(const uint32_t idx,
   if (pred->use() != Use::kAlley && edge->use() == Use::kAlley) {
     penalty += alley_penalty_;
   }
-  if (!node->name_consistency(idx, edge->localedgeidx())) {
+  // Ignore name inconsistency when entering a link to avoid double penalizing.
+  if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;
   }
 


### PR DESCRIPTION
depends on valhalla/mjolnir#581

``` diff
< BEFORE
< Turn right onto Tysons Boulevard. | 0.2 mi
< Continue. | 0.2 mi
< Continue on Tysons Boulevard. | 0.3 mi

> AFTER
> Turn right onto Tysons Boulevard. | 0.7 mi
```